### PR TITLE
fix: use the file suffix when importing with relative paths

### DIFF
--- a/src/disposable.mts
+++ b/src/disposable.mts
@@ -1,4 +1,4 @@
-import type { Pointer } from './libxml2raw';
+import type { Pointer } from './libxml2raw.js';
 import './disposeShim.mjs';
 import './metadataShim.mjs';
 

--- a/src/document.mts
+++ b/src/document.mts
@@ -9,7 +9,7 @@ import {
 } from './libxml2.mjs';
 import { XmlElement, XmlNode } from './nodes.mjs';
 import { XmlXPath, NamespaceMap } from './xpath.mjs';
-import type { XmlDocPtr } from './libxml2raw';
+import type { XmlDocPtr } from './libxml2raw.js';
 import { disposeBy, XmlDisposable } from './disposable.mjs';
 
 export enum ParseOption {

--- a/src/validates.mts
+++ b/src/validates.mts
@@ -23,7 +23,7 @@ import type {
     XmlRelaxNGPtr,
     XmlSchemaParserCtxtPtr,
     XmlSchemaPtr,
-} from './libxml2raw';
+} from './libxml2raw.js';
 import { disposeBy, XmlDisposable } from './disposable.mjs';
 
 export class XmlValidateError extends XmlError {}


### PR DESCRIPTION
Fixes the issue "Relative import paths need explicit file extensions in EcmaScript imports when '--moduleResolution' is 'node16' or 'nodenext'."

Since other relative imports use the suffix, I thought it would help to import libxml2raw also with the suffix. There might be a reason the suffix was left out for that, which I missed. Any other solutions are appreciated.

p.s. I think this library will be a good replacement for libxmljs and libxmljs2, thank you for the work.

p.p.s I'm also dealing with an issue where I cannot keep my project module: CommonJS, because Typescript then converts my async imports into requires. I had to set module: Node16, which then resulted in this problem.