### PR TITLE
fix: use the file suffix when importing with relative paths (#18)

### DIFF
--- a/src/disposable.mts
+++ b/src/disposable.mts
@@ -1,4 +1,4 @@
-import type { Pointer } from './libxml2raw';
+import type { Pointer } from './libxml2raw.js';
 import './disposeShim.mjs';
 import './metadataShim.mjs';
 

--- a/src/document.mts
+++ b/src/document.mts
@@ -9,7 +9,7 @@ import {
 } from './libxml2.mjs';
 import { XmlElement, XmlNode } from './nodes.mjs';
 import { XmlXPath, NamespaceMap } from './xpath.mjs';
-import type { XmlDocPtr } from './libxml2raw';
+import type { XmlDocPtr } from './libxml2raw.js';
 import { disposeBy, XmlDisposable } from './disposable.mjs';
 
 export enum ParseOption {

--- a/src/validates.mts
+++ b/src/validates.mts
@@ -23,7 +23,7 @@ import type {
     XmlRelaxNGPtr,
     XmlSchemaParserCtxtPtr,
     XmlSchemaPtr,
-} from './libxml2raw';
+} from './libxml2raw.js';
 import { disposeBy, XmlDisposable } from './disposable.mjs';
 
 export class XmlValidateError extends XmlError {}


### PR DESCRIPTION
In my project Node complains: "Relative import paths need explicit file extensions in EcmaScript imports when '--moduleResolution' is 'node16' or 'nodenext'." Since other relative imports use the suffix, I thought it would help to import libxml2raw also with the suffix.

(cherry picked from commit 9f0afa32cf82a30ce4198ac13a73e3934cfc6fd9)