### PR TITLE
Revise XmlInputProvider and xmlRegisterInputProvider

### DIFF
--- a/src/nodejs.mts
+++ b/src/nodejs.mts
@@ -31,7 +31,7 @@ function fileExists(filename: string): boolean {
  *
  * @see {@link libxml2-wasm!xmlRegisterInputProvider}
  */
-export const fsInputProviders: XmlInputProvider<number> = {
+export const fsInputProviders: XmlInputProvider = {
     match(filename: string) {
         return fileExists(filename);
     },

--- a/test/crossplatform/validates.spec.mts
+++ b/test/crossplatform/validates.spec.mts
@@ -232,7 +232,7 @@ describe('XsdValidator', () => {
         ];
 
         before(() => {
-            const provider: XmlInputProvider<number> = {
+            const provider: XmlInputProvider = {
                 match: (filename: string) => {
                     if (filename.endsWith('.xsd') || filename.endsWith('.xml')) {
                         return true;


### PR DESCRIPTION
- file descriptor uses fixed type: number, which is compatible with wasm
- directly read into wasm-shared buffer
