### PR TITLE
Rewrite XmlDisposable, maintaining 1 to 1 relationship to libxml object to avoid re-releasing

### DIFF
--- a/docs/validate.md
+++ b/docs/validate.md
@@ -42,7 +42,7 @@ you could create an {@link libxml2-wasm!XmlXPath | `XmlXPath`} object to avoid r
 ```js
 import { XmlDocument, XmlXPath } from 'libxml2-wasm';
 
-const xpath = new XmlXPath('/book/title');
+const xpath = XmlXPath.create('/book/title');
 const doc1 = XmlDocument.fromString('<book><title>Harry Potter</title></book>');
 const doc2 = XmlDocument.fromString('<book><title>Learning XML</title></book>');
 console.log(doc1.get(xpath).content); // Harry Potter

--- a/src/document.mts
+++ b/src/document.mts
@@ -105,25 +105,13 @@ export interface SaveOptions {
     format?: boolean;
 }
 
-export class XmlDocument extends XmlDisposable {
-    /** @internal */
-    @disposeBy(xmlFreeDoc)
-    accessor _docPtr: number;
-
-    /** Create a document object wrapping document parsed by libxml2.
-     * @see {@link parseXmlString}
-     * @internal
-     */
-    private constructor(xmlDocPtr: XmlDocPtr) {
-        super();
-        this._docPtr = xmlDocPtr;
-    }
-
+@disposeBy(xmlFreeDoc)
+export class XmlDocument extends XmlDisposable<XmlDocument> {
     /** Create a new document from scratch.
      * To parse an existing xml, use {@link fromBuffer} or {@link fromString}.
      */
     static create(): XmlDocument {
-        return new XmlDocument(xmlNewDoc());
+        return XmlDocument.getInstance(xmlNewDoc());
     }
 
     /**
@@ -194,7 +182,7 @@ export class XmlDocument extends XmlDisposable {
             error.storage.free(incErr);
             xmlXIncludeFreeContext(xinc);
         }
-        return new XmlDocument(xml);
+        return XmlDocument.getInstance(xml);
     }
 
     /**
@@ -227,7 +215,7 @@ export class XmlDocument extends XmlDisposable {
      */
     toBuffer(handler: XmlOutputBufferHandler, options?: SaveOptions) {
         const buf = xmlOutputBufferCreate(handler);
-        xmlSaveFormatFileTo(buf, this._docPtr, null, options?.format ?? true ? 1 : 0);
+        xmlSaveFormatFileTo(buf, this._ptr, null, options?.format ?? true ? 1 : 0);
     }
 
     get(xpath: XmlXPath): XmlNode | null;
@@ -266,7 +254,7 @@ export class XmlDocument extends XmlDisposable {
      * {@link XmlError} will be thrown.
      */
     get root(): XmlElement {
-        const root = xmlDocGetRootElement(this._docPtr);
+        const root = xmlDocGetRootElement(this._ptr);
         if (!root) {
             // TODO: get error information from libxml2
             throw new XmlError();

--- a/src/xpath.mts
+++ b/src/xpath.mts
@@ -20,19 +20,16 @@ export interface NamespaceMap {
  *
  * Note: This object requires to be {@link dispose}d explicitly.
  */
-export class XmlXPath extends XmlDisposable {
-    /** @internal */
-    @disposeBy(xmlXPathFreeCompExpr)
-    accessor _xpath: XmlXPathCompExprPtr;
-
+@disposeBy(xmlXPathFreeCompExpr)
+export class XmlXPath extends XmlDisposable<XmlXPath> {
     private readonly _xpathSource;
 
     private readonly _namespaces: NamespaceMap | undefined;
 
-    constructor(xpath: string, namespaces?: NamespaceMap) {
-        super();
-        this._xpathSource = xpath;
-        this._xpath = xmlXPathCtxtCompile(0, xpath);
+    /** @internal */
+    constructor(xpath: XmlXPathCompExprPtr, xpathStr: string, namespaces?: NamespaceMap) {
+        super(xpath);
+        this._xpathSource = xpathStr;
         this._namespaces = namespaces;
     }
 
@@ -48,5 +45,15 @@ export class XmlXPath extends XmlDisposable {
      */
     toString(): string {
         return this._xpathSource;
+    }
+
+    /**
+     * Create a new XPath object.
+     * @param xpathStr The XPath string
+     * @param namespaces Namespace map for prefixes used in the xpathStr
+     */
+    static create(xpathStr: string, namespaces?: NamespaceMap): XmlXPath {
+        const xpath = XmlXPath.getInstance(xmlXPathCtxtCompile(0, xpathStr), xpathStr, namespaces);
+        return xpath;
     }
 }

--- a/test/crossplatform/xpath.spec.mts
+++ b/test/crossplatform/xpath.spec.mts
@@ -11,21 +11,21 @@ describe('XPath', () => {
     });
 
     it('could be used in get method of multiple docs', () => {
-        const xpath = new XmlXPath('/book/title');
+        const xpath = XmlXPath.create('/book/title');
         expect(doc1.get(xpath)?.content).to.equal('Harry Potter');
         expect(doc2.get(xpath)?.content).to.equal('Learning XML');
         xpath.dispose();
     });
 
     it('could be used in find method of multiple docs', () => {
-        const xpath = new XmlXPath('/book/title');
+        const xpath = XmlXPath.create('/book/title');
         expect(doc1.find(xpath).map((node) => node.content)).to.deep.equal(['Harry Potter']);
         expect(doc2.find(xpath).map((node) => node.content)).to.deep.equal(['Learning XML']);
         xpath.dispose();
     });
 
     it('should handle null xpath string', () => {
-        const xpath = new XmlXPath(null!);
+        const xpath = XmlXPath.create(null!);
         xpath.dispose();
     });
 
@@ -33,26 +33,26 @@ describe('XPath', () => {
         using doc = XmlDocument.fromString(
             '<book xmlns:t="http://foo"><t:title>Harry Potter</t:title></book>',
         );
-        const xpath = new XmlXPath('/book/m:title', { m: 'http://foo' });
+        const xpath = XmlXPath.create('/book/m:title', { m: 'http://foo' });
         expect(doc.get(xpath)?.content).to.equal('Harry Potter');
         expect(doc.find(xpath).map((node) => node.content)).to.deep.equal(['Harry Potter']);
         xpath.dispose();
     });
 
     it('should return undefined if namespace is not provided', () => {
-        const xpath = new XmlXPath(('/book'));
+        const xpath = XmlXPath.create(('/book'));
         expect(xpath.namespaces).to.be.undefined;
         xpath.dispose();
     });
 
     it('should return namespaces passed in', () => {
-        const xpath = new XmlXPath('/book/m:title', { m: 'http://foo' });
+        const xpath = XmlXPath.create('/book/m:title', { m: 'http://foo' });
         expect(xpath.namespaces).to.deep.equal({ m: 'http://foo' });
         xpath.dispose();
     });
 
     it('should return xpath string by toString', () => {
-        const xpath = new XmlXPath(('/book'));
+        const xpath = XmlXPath.create('/book');
         expect(xpath.toString()).to.equal('/book');
         xpath.dispose();
     });

--- a/test/disposable.spec.mts
+++ b/test/disposable.spec.mts
@@ -1,73 +1,74 @@
 import { expect } from 'chai';
 import { disposeBy, XmlDisposable } from '../src/disposable.mjs';
 
-function fixture(free1: number[], free2: number[]) {
-    return class Fixture extends XmlDisposable {
-        @disposeBy((val) => { free1.push(val); })
-        accessor p1: number
+function fixture(free: number[]) {
+    @disposeBy((val) => { free.push(val); })
+    class Fixture extends XmlDisposable<Fixture> {
+    }
 
-        @disposeBy((val) => { free2.push(val); })
-        accessor p2: number
-
-        constructor() {
-            super();
-            this.p1 = 51;
-            this.p2 = 52;
-        }
-    };
+    return Fixture;
 }
 
-describe('Dispose', () => {
+describe('Disposable', () => {
     it('gc should release unused', async () => {
         const f1: number[] = [];
-        const f2: number[] = [];
 
-        {
-            const Fixture = fixture(f1, f2);
-            new Fixture(); // eslint-disable-line no-new
-        }
+        const Fixture = fixture(f1);
+        Fixture.getInstance(51);
 
-        // reset array, preparing for gc
-        f1.length = 0;
-        f2.length = 0;
+        await new Promise((resolve) => { setTimeout(resolve, 0); });
         (global as any).gc();
         // allow finalizer to run
-        await new Promise((resolve) => { setTimeout(resolve, 500); });
+        await new Promise((resolve) => { setTimeout(resolve, 0); });
 
         expect(f1).to.deep.equal([51]);
-        expect(f2).to.deep.equal([52]);
     });
 
     it('disposed object should not be release again', async () => {
         const f1: number[] = [];
-        const f2: number[] = [];
 
         {
-            const Fixture = fixture(f1, f2);
-            const obj = new Fixture();
+            const Fixture = fixture(f1);
+            const obj = Fixture.getInstance(41);
             obj.dispose();
         }
 
-        // reset array, preparing for gc
+        // explict call to dispose already freed the resource and record it in f1 array, reset it.
         f1.length = 0;
-        f2.length = 0;
+        await new Promise((resolve) => { setTimeout(resolve, 0); });
         (global as any).gc();
-        // allow finalizer to run
-        await new Promise((resolve) => { setTimeout(resolve, 500); });
+        // allow finalizer to finish
+        await new Promise((resolve) => { setTimeout(resolve, 0); });
 
         expect(f1).to.deep.equal([]);
-        expect(f2).to.deep.equal([]);
     });
 
-    it('should release previous value when new value is assigned', () => {
+    it('creates instance only when needed', () => {
         const f1: number[] = [];
         const f2: number[] = [];
+        const Fixture1 = fixture(f1);
+        const Fixture2 = fixture(f2);
 
-        const Fixture = fixture(f1, f2);
-        const obj = new Fixture();
+        const inst = Fixture1.getInstance(4);
+        const inst2 = Fixture1.getInstance(4);
+        const inst3 = Fixture1.getInstance(3);
+        const inst4 = Fixture2.getInstance(4);
 
-        obj.p1 = 42;
+        expect(inst2).to.equal(inst); // same instance to inst
+        expect(inst3).to.not.equal(inst); // different instance because ptr is different
+        expect(inst4).to.not.equal(inst); // different instance because class is different
+    });
 
-        expect(f1).to.deep.equal([51]);
+    it('creates new instance after dispose', () => {
+        const f1: number[] = [];
+        const Fixture = fixture(f1);
+        f1.length = 0;
+        const inst1 = Fixture.getInstance(11);
+        inst1.dispose();
+        // inst1 is disposed (ptr 11 is free), verify it creates new instance
+        const inst2 = Fixture.getInstance(11);
+
+        expect(inst2).to.not.equal(inst1); // inst1 and inst2 are not same instance
+        expect(f1).to.deep.equal([11]);
     });
 });


### PR DESCRIPTION
The constructors have to be internal because the internal id/pointer of libxml object need to be passed.
