### PR TITLE
Initialize the libxml as soon as the wasm module loaded

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -1,6 +1,7 @@
 {
   "exclude": [
-    "lib/libxml2raw.cjs"
+    "lib/libxml2raw.cjs",
+    "test/*"
   ],
   "reporter": [
     "text",

--- a/binding/exported-functions.txt
+++ b/binding/exported-functions.txt
@@ -11,6 +11,7 @@ _xmlFreeParserCtxt
 _xmlGetLastError
 _xmlGetNsList
 _xmlHasNsProp
+_xmlInitParser
 _xmlNewDoc
 _xmlNewDocNode
 _xmlNewDocText

--- a/src/libxml2.mts
+++ b/src/libxml2.mts
@@ -15,6 +15,7 @@ import moduleLoader from './libxml2raw.cjs';
 import { ContextStorage } from './utils.mjs';
 
 const libxml2 = await moduleLoader();
+libxml2._xmlInitParser();
 
 /**
  * Base class for exceptions.

--- a/src/libxml2raw.d.cts
+++ b/src/libxml2raw.d.cts
@@ -52,6 +52,7 @@ export class LibXml2 {
     _xmlGetLastError(): XmlErrorPtr;
     _xmlGetNsList(doc: XmlDocPtr, node: XmlNodePtr): Pointer;
     _xmlHasNsProp(node: XmlNodePtr, name: CString, namespace: CString): XmlAttrPtr;
+    _xmlInitParser(): void;
     _xmlNewDoc(): XmlDocPtr;
     _xmlNewDocNode(doc: XmlDocPtr, ns: XmlNsPtr, name: CString, content: CString): XmlNodePtr;
     _xmlNewNs(node: XmlNodePtr, href: CString, prefix: CString): XmlNsPtr;

--- a/test/initialization.test.js
+++ b/test/initialization.test.js
@@ -1,0 +1,23 @@
+const fs = require('node:fs');
+
+import('../lib/nodejs.mjs').then(({ xmlRegisterFsInputProviders }) => {
+    import('../lib/index.mjs').then(({
+        xmlCleanupInputProvider,
+        XmlDocument,
+        XsdValidator,
+    }) => {
+        xmlRegisterFsInputProviders();
+
+        const schemaDoc = XmlDocument.fromBuffer(fs.readFileSync('test/testfiles/book.xsd'), { url: 'test/testfiles/book.xsd' });
+        const validator = XsdValidator.fromDoc(schemaDoc);
+        const doc = XmlDocument.fromBuffer(fs.readFileSync('test/testfiles/book.xml'), { url: 'test/testfiles/book.xml' });
+        try {
+            validator.validate(doc);
+        } finally {
+            doc.dispose();
+            validator.dispose();
+            schemaDoc.dispose();
+            xmlCleanupInputProvider();
+        }
+    });
+});

--- a/test/nodejs.spec.mts
+++ b/test/nodejs.spec.mts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import { execSync } from 'node:child_process';
 import { resolve } from 'node:path';
 import * as chai from 'chai';
 import sinon from 'sinon';
@@ -147,5 +148,12 @@ describe('saveDocSync', () => {
 
         expect(calledWithCorrectArg).to.have.been.called;
         expect(closeStub).to.have.been.calledWith(42);
+    });
+});
+
+describe('Initialization', () => {
+    it('works when register io callbacks at the beginning', () => {
+        // execute in external process to test the initialization
+        execSync(`"${process.execPath}" test/initialization.test.js`);
     });
 });


### PR DESCRIPTION
So some APIs that doesn't initialize the library could be used before others.
