### PR TITLE
Convert an XmlElement to string, or save it with callbacks

### DIFF
--- a/binding/exported-functions.txt
+++ b/binding/exported-functions.txt
@@ -43,7 +43,10 @@ _xmlRelaxNGSetValidStructuredErrors
 _xmlRelaxNGValidateDoc
 _xmlRemoveProp
 _xmlResetLastError
+_xmlSaveClose
 _xmlSaveFormatFileTo
+_xmlSaveToIO
+_xmlSaveTree
 _xmlSchemaNewDocParserCtxt
 _xmlSchemaFree
 _xmlSchemaFreeParserCtxt

--- a/docs/io.md
+++ b/docs/io.md
@@ -80,12 +80,12 @@ which implements {@link libxml2-wasm!XmlInputProvider | `XmlInputProvider`} and 
 
 # Serialize an XML
 
-{@link libxml2-wasm!XmlDocument.toBuffer | `XmlDocument.toBuffer`} gradually dumps the content of the XML DOM tree into a buffer 
+{@link libxml2-wasm!XmlDocument.save | `XmlDocument.save`} gradually dumps the content of the XML DOM tree into a buffer 
 and calls the {@link libxml2-wasm!XmlOutputBufferHandler | `XmlOutputBufferHandler`} to process the data.
 
 Please note that UTF-8 is the only supported encoding at this time.
 
-Based on `toBuffer`, 
+Based on `save`, 
 {@link libxml2-wasm!XmlDocument.toString | `XmlDocument.toString`} is a convenience functions to get an XML string.
 
 For instance, to save an XML as a compact string, use:
@@ -130,7 +130,7 @@ const fd = fs.openSync('doc.xml', 'w');
 saveDocSync(xml, fd);
 ```
 
-`saveDocSync` uses {@link libxml2-wasm!XmlDocument.toBuffer | `XmlDocument.toBuffer`},
+`saveDocSync` uses {@link libxml2-wasm!XmlDocument.save | `XmlDocument.save`},
 which is faster than {@link libxml2-wasm!XmlDocument.toString | `XmlDocument.toString`}
 because similar to [`XmlDocument.fromBuffer` and `XmlDocument.fromString`](performance.md),
 it doesn't need to convert UTF-8 to UTF-16 and then convert it back.

--- a/src/libxml2.mts
+++ b/src/libxml2.mts
@@ -8,6 +8,7 @@ import type {
     XmlNsPtr,
     XmlOutputBufferPtr,
     XmlParserCtxtPtr,
+    XmlSaveCtxtPtr,
     XmlXPathCompExprPtr,
     XmlXPathContextPtr,
 } from './libxml2raw.mjs';
@@ -514,7 +515,17 @@ const ioclose = libxml2.addFunction(
 
 export function xmlOutputBufferCreate(handler: XmlOutputBufferHandler): XmlOutputBufferPtr {
     const index = saveHandlerStorage.allocate(handler);
-    return libxml2._xmlOutputBufferCreateIO(iowrite, ioclose, index, 0);
+    return libxml2._xmlOutputBufferCreateIO(iowrite, ioclose, index, 0); // will be freed in ioclose
+}
+
+export function xmlSaveToIO(
+    handler: XmlOutputBufferHandler,
+    encoding: string | null,
+    format: number,
+): XmlSaveCtxtPtr {
+    const index = saveHandlerStorage.allocate(handler); // will be freed in ioclose
+    // Support only UTF-8 as of now
+    return libxml2._xmlSaveToIO(iowrite, ioclose, index, 0, format);
 }
 
 export function xmlSaveFormatFileTo(
@@ -554,6 +565,8 @@ export const xmlRelaxNGSetValidStructuredErrors = libxml2._xmlRelaxNGSetValidStr
 export const xmlRelaxNGValidateDoc = libxml2._xmlRelaxNGValidateDoc;
 export const xmlRemoveProp = libxml2._xmlRemoveProp;
 export const xmlResetLastError = libxml2._xmlResetLastError;
+export const xmlSaveClose = libxml2._xmlSaveClose;
+export const xmlSaveTree = libxml2._xmlSaveTree;
 export const xmlSchemaFree = libxml2._xmlSchemaFree;
 export const xmlSchemaFreeParserCtxt = libxml2._xmlSchemaFreeParserCtxt;
 export const xmlSchemaFreeValidCtxt = libxml2._xmlSchemaFreeValidCtxt;

--- a/src/libxml2raw.d.mts
+++ b/src/libxml2raw.d.mts
@@ -14,6 +14,7 @@ type XmlOutputWriteCallback = Pointer;
 type XmlRelaxNGParserCtxtPtr = Pointer;
 type XmlRelaxNGPtr = Pointer;
 type XmlRelaxNGValidCtxtPtr = Pointer;
+type XmlSaveCtxtPtr = Pointer;
 type XmlSchemaParserCtxtPtr = Pointer;
 type XmlSchemaPtr = Pointer;
 type XmlSchemaValidCtxtPtr = Pointer;
@@ -102,12 +103,21 @@ export class LibXml2 {
     _xmlRelaxNGValidateDoc(ctxt: XmlRelaxNGValidCtxtPtr, doc: XmlDocPtr): number;
     _xmlRemoveProp(cur: XmlAttrPtr): number;
     _xmlResetLastError(): void;
+    _xmlSaveClose(ctxt: XmlSaveCtxtPtr): void;
     _xmlSaveFormatFileTo(
         buf: XmlOutputBufferPtr,
         doc: XmlDocPtr,
         encoding: CString,
         format: number,
     ): number;
+    _xmlSaveToIO(
+        iowrite: XmlOutputWriteCallback,
+        ioclose: XmlOutputCloseCallback,
+        context: Pointer,
+        encoding: CString,
+        options: number,
+    ): XmlSaveCtxtPtr;
+    _xmlSaveTree(ctxt: XmlSaveCtxtPtr, node: XmlNodePtr): number;
     _xmlSearchNs(doc: XmlDocPtr, node: XmlNodePtr, prefix: CString): XmlNsPtr;
     _xmlSetNs(node: XmlNodePtr, ns: XmlNsPtr): void;
     _xmlSetNsProp(node: XmlNodePtr, ns: XmlNsPtr, name: CString, value: CString): XmlAttrPtr;

--- a/src/nodejs.mts
+++ b/src/nodejs.mts
@@ -97,5 +97,5 @@ export function saveDocSync(doc: XmlDocument, fd: number, options?: SaveOptions)
             return true;
         },
     };
-    doc.toBuffer(handler, options);
+    doc.save(handler, options);
 }

--- a/src/utils.mts
+++ b/src/utils.mts
@@ -1,4 +1,4 @@
-import { XmlInputProvider } from './libxml2.mjs';
+import { XmlInputProvider, XmlOutputBufferHandler } from './libxml2.mjs';
 import { Pointer } from './libxml2raw.mjs';
 
 /**
@@ -122,4 +122,23 @@ export function readBuffer(fd: number, buffer: Uint8Array): number {
  */
 export function closeBuffer(fd: Pointer) {
     bufferContexts.delete(fd);
+}
+
+export class XmlStringOutputBufferHandler implements XmlOutputBufferHandler {
+    private _result = '';
+
+    private _decoder = new TextDecoder();
+
+    write(buf: Uint8Array): number {
+        this._result += this._decoder.decode(buf);
+        return buf.byteLength;
+    }
+
+    close(): boolean { // eslint-disable-line class-methods-use-this
+        return true;
+    }
+
+    get result(): string {
+        return this._result;
+    }
 }

--- a/test/crossplatform/document.spec.mts
+++ b/test/crossplatform/document.spec.mts
@@ -7,6 +7,7 @@ import {
     XmlError,
     xmlRegisterInputProvider,
 } from '@libxml2-wasm/lib/index.mjs';
+import { XmlStringOutputBufferHandler } from '@libxml2-wasm/lib/utils.mjs';
 
 describe('XmlDocument', () => {
     const doc = XmlDocument.fromString('<docs><doc></doc></docs>');
@@ -82,6 +83,19 @@ describe('XmlDocument', () => {
             expect(doc.get('docs')).to.be.null;
             expect((doc.get('doc') as XmlElement).name).to.equal('doc');
             expect((doc.get('/docs/doc') as XmlElement).name).to.equal('doc');
+        });
+    });
+
+    describe('toBuffer (deprecated)', () => {
+        it('formats output by default', () => {
+            const handler = new XmlStringOutputBufferHandler();
+            doc.toBuffer(handler);
+            expect(handler.result).to.equal(`\
+<?xml version="1.0"?>
+<docs>
+  <doc/>
+</docs>
+`);
         });
     });
 

--- a/test/crossplatform/nodes.spec.mts
+++ b/test/crossplatform/nodes.spec.mts
@@ -706,6 +706,14 @@ describe('XmlElement', () => {
         });
     });
 
+    describe('toString', () => {
+        it('should return the XML string representation of the node', () => {
+            using newDoc = XmlDocument.fromString('<docs><doc>text</doc></docs>');
+            const node = newDoc.get('/docs/doc');
+            expect(node?.toString()).to.equal('<doc>text</doc>');
+        });
+    });
+
     describe('localNamespaces (deprecated)', () => {
         it('should return the same value as nsDeclarations', () => {
             using newDoc = XmlDocument.fromString('<docs xmlns:ex="http://example.com"/>');


### PR DESCRIPTION
Also renamed `toBuffer` to `save`
