### PR TITLE
Exported Runtime Functions

### DIFF
--- a/binding/exported-runtime-functions.txt
+++ b/binding/exported-runtime-functions.txt
@@ -3,3 +3,5 @@ addFunction
 getValue
 lengthBytesUTF8
 stringToUTF8
+HEAP32
+HEAPU8


### PR DESCRIPTION
After following directions for compiling and testing. I ran into error messages from the test that `HEAPU8` and `HEAP32` were not exported. After goolging around how to pass the proper flag to emscripten taken into account how the build pipeline is setup. I read the `contributing.md` and decided to make this quick PR for this small issue. 

- adding required runtime-functions for latest version of emscripten