### PR TITLE
Add addClone method to XmlElement

### DIFF
--- a/binding/exported-functions.txt
+++ b/binding/exported-functions.txt
@@ -11,6 +11,7 @@ _xmlCtxtSetErrorHandler
 _xmlCtxtValidateDtd
 _xmlDocGetRootElement
 _xmlDocSetRootElement
+_xmlDOMWrapCloneNode
 _xmlFreeDoc
 _xmlFreeDtd
 _xmlFreeNode

--- a/src/libxml2.mts
+++ b/src/libxml2.mts
@@ -79,6 +79,31 @@ function allocUTF8Buffer(str: string | null) {
     return [buf, len];
 }
 
+class PointerRef<T extends Pointer> {
+  ptr: Pointer;
+
+  constructor(ptr: Pointer) {
+    this.ptr = ptr;
+  }
+
+  dereference(): T {
+    return libxml2.getValue(this.ptr, '*') as T;
+  }
+}
+
+// TODO: find out actual pointer size
+const POINTER_SIZE = 8;
+
+export function withPointerRef<T extends Pointer, R>(process: (pointerRef: PointerRef<T>) => R): R {
+  const buf = libxml2._malloc(POINTER_SIZE);
+
+  try {
+    return process(new PointerRef<T>(buf));
+  } finally {
+    libxml2._free(buf);
+  }
+}
+
 function withStrings<R>(process: (...buf: number[]) => R, ...strings: (string | null)[]): R {
     const args = strings.map((str) => {
         const [buf] = allocUTF8Buffer(str);
@@ -725,6 +750,7 @@ export const xmlXPathFreeContext = libxml2._xmlXPathFreeContext;
 export const xmlXPathFreeObject = libxml2._xmlXPathFreeObject;
 export const xmlXPathNewContext = libxml2._xmlXPathNewContext;
 export const xmlXPathSetContextNode = libxml2._xmlXPathSetContextNode;
+export const xmlDOMWrapCloneNode = libxml2._xmlDOMWrapCloneNode;
 
 /**
  * Create an output buffer using I/O callbacks (same pattern as xmlSaveToIO)

--- a/src/libxml2raw.d.mts
+++ b/src/libxml2raw.d.mts
@@ -2,6 +2,7 @@ type Pointer = number;
 type CString = Pointer;
 type XmlAttrPtr = Pointer;
 type XmlCharEncodingHandlerPtr = Pointer;
+type XMLDomWrapCtxtPtr = Pointer;
 type XmlParserCtxtPtr = Pointer;
 type XmlParserInputBufferPtr = Pointer;
 type XmlDocPtr = Pointer;
@@ -62,6 +63,16 @@ export class LibXml2 {
     _xmlCtxtValidateDtd(ctxt: XmlParserCtxtPtr, doc: XmlDocPtr, dtd: XmlDtdPtr): number;
     _xmlFreeNode(node: XmlNodePtr): void;
     _xmlFreeParserCtxt(ctxt: XmlParserCtxtPtr): void;
+    _xmlDOMWrapCloneNode(
+      ctxt: XMLDomWrapCtxtPtr,
+      sourceDoc: XmlDocPtr,
+      node: XmlNodePtr,
+      resNode: Pointer,
+      destDoc: XmlDocPtr,
+      destParent: XmlDocPtr,
+      deep: number,
+      options: number,
+    ): number;
     _xmlDocGetRootElement(doc: XmlDocPtr): XmlNodePtr;
     _xmlDocSetRootElement(doc: XmlDocPtr, root: XmlNodePtr): XmlNodePtr;
     _xmlFreeDoc(Doc: XmlDocPtr): void;

--- a/src/nodes.mts
+++ b/src/nodes.mts
@@ -8,9 +8,11 @@ import {
     XmlNsStruct,
     XmlOutputBufferHandler,
     XmlXPathObjectStruct,
+    withPointerRef,
     xmlAddChild,
     xmlAddNextSibling,
     xmlAddPrevSibling,
+    xmlDOMWrapCloneNode,
     xmlFreeNode,
     xmlGetNsList,
     xmlHasNsProp,
@@ -796,6 +798,37 @@ export class XmlElement extends XmlTreeNode {
         return new XmlEntityReference(
             addNode(this._nodePtr, name, xmlNewReference, xmlAddChild),
         );
+    }
+
+    /**
+     * Insert a clone of the given source node to the end of the children list.
+     */
+    addClone(srcNode: XmlElement, deep: boolean = true): XmlElement {
+      return withPointerRef((resNodePtr) => {
+        const result = xmlDOMWrapCloneNode(
+          0,
+          srcNode.doc._ptr,
+          srcNode._nodePtr,
+          resNodePtr.ptr,
+          this.doc._ptr,
+          this._nodePtr,
+          deep ? 1 : 0,
+          0,
+        );
+
+        switch (result) {
+          case 0:
+            {
+              const resNode = resNodePtr.dereference();
+              xmlAddChild(this._nodePtr, resNode);
+              return new XmlElement(resNode);
+            }
+          case 1:
+            throw new Error('Unsupported node type given to addClone');
+          default:
+            throw new Error('Internal error in addClone');
+        }
+      });
     }
 
     /**


### PR DESCRIPTION
Add an `addClone` function to `XmlElement` to allow adding cloned children from one document to another.

Example:
```js
const { XmlDocument } = await import ('libxml2-wasm');
const doc1 = XmlDocument.fromString('<foo><bar>hello</bar></foo>');
const doc2 = XmlDocument.fromString('<root><baz>Ahoy matey!</baz></root>');
const foo = doc1.get('/foo');
const baz = doc2.get('//baz');
foo.addClone(baz);
console.log(doc1.toString());
```

outputs:

```
<?xml version="1.0" encoding="utf-8"?>
<foo>
  <bar>hello</bar>
  <baz>Ahoy matey!</baz>
</foo>
```