### PR TITLE
Remove automatic XInclude processing

### DIFF
--- a/src/document.mts
+++ b/src/document.mts
@@ -99,6 +99,7 @@ export enum ParseOption {
     /**
      * Enable XInclude processing. This option only affects the xmlTextReader
      * and XInclude interfaces.
+     * @deprecated
      */
     XML_PARSE_XINCLUDE = 1 << 10,
     /**
@@ -250,9 +251,6 @@ function parse<Input>(
         throw new XmlParseError('Failed to parse XML', []);
     }
     const xmlDocument = XmlDocument.getInstance(xml);
-    if (xmlOptions & ParseOption.XML_PARSE_XINCLUDE) {
-        xmlDocument.processXInclude();
-    }
     return xmlDocument;
 }
 

--- a/test/backend/nodejs.spec.mts
+++ b/test/backend/nodejs.spec.mts
@@ -5,7 +5,6 @@ import * as chai from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import {
-    ParseOption,
     xmlCleanupInputProvider,
     XmlDocument,
     XmlValidateError,
@@ -34,8 +33,9 @@ describe('Node.js input callbacks', () => {
         using validator = XsdValidator.fromDoc(schemaDoc);
         using doc = XmlDocument.fromBuffer(
             fs.readFileSync('test/testfiles/book.xml'),
-            { url: 'test/testfiles/book.xml', option: ParseOption.XML_PARSE_XINCLUDE },
+            { url: 'test/testfiles/book.xml' },
         );
+        doc.processXInclude();
         validator.validate(doc);
     });
 
@@ -47,8 +47,9 @@ describe('Node.js input callbacks', () => {
         using validator = XsdValidator.fromDoc(schemaDoc);
         using doc = XmlDocument.fromBuffer(
             fs.readFileSync('test/testfiles/book.xml'),
-            { url: join('test', 'testfiles', 'book.xml'), option: ParseOption.XML_PARSE_XINCLUDE },
+            { url: join('test', 'testfiles', 'book.xml') },
         );
+        doc.processXInclude();
         validator.validate(doc);
     });
 
@@ -62,17 +63,18 @@ describe('Node.js input callbacks', () => {
             fs.readFileSync('test/testfiles/book.xml'),
             {
                 url: `file:///${resolve('test/testfiles/book.xml').replaceAll('\\', '/')}`,
-                option: ParseOption.XML_PARSE_XINCLUDE,
             },
         );
+        doc.processXInclude();
         validator.validate(doc);
     });
 
     it('can read big file', () => {
         using doc = XmlDocument.fromBuffer(
             fs.readFileSync('test/testfiles/geography.xml'),
-            { url: 'test/testfiles/geography.xml', option: ParseOption.XML_PARSE_XINCLUDE },
+            { url: 'test/testfiles/geography.xml' },
         );
+        doc.processXInclude();
 
         expect(doc.get('//country/capital[../name="United States"]')?.content).to.equal('Washington D.C.');
     });
@@ -191,8 +193,9 @@ describe('Path handling', () => {
         it('handles backslash on Windows', () => {
             using doc = XmlDocument.fromString(
                 '<book><title>Dune</title><xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="author.xml" /></book>',
-                { url: 'test\\testfiles\\book.xml', option: ParseOption.XML_PARSE_XINCLUDE },
+                { url: 'test\\testfiles\\book.xml' },
             );
+            doc.processXInclude();
             expect(doc.get('/book/author/first-name')?.content).to.equal('Frank');
         });
     } else {
@@ -201,8 +204,9 @@ describe('Path handling', () => {
             // so the include xml should be test/testfiles/author.xml
             using doc = XmlDocument.fromString(
                 '<book><title>Dune</title><xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="author.xml" /></book>',
-                { url: 'test/testfiles/book\\test.xml', option: ParseOption.XML_PARSE_XINCLUDE },
+                { url: 'test/testfiles/book\\test.xml' },
             );
+            doc.processXInclude();
             expect(doc.get('/book/author/first-name')?.content).to.equal('Frank');
         });
     }

--- a/test/crossplatform/parseXml.spec.mts
+++ b/test/crossplatform/parseXml.spec.mts
@@ -173,34 +173,16 @@ describe('XInclude', () => {
         expect(inc.attr('href')?.content).to.equal('sub.xml');
     });
 
-    it('should process xml with XInclude', () => {
+    it('wont process xml with XInclude even with XML_PARSE_XINCLUDE flag', () => {
         registerCallbacks('path/sub.xml', '<sub foo="bar"></sub>');
         using doc = XmlDocument.fromString(
             '<doc xmlns:xi="http://www.w3.org/2001/XInclude"><xi:include href="sub.xml"></xi:include></doc>',
             { url: 'path/doc.xml', option: ParseOption.XML_PARSE_XINCLUDE },
         );
 
-        expect(doc.get('/doc/sub/@foo')?.content).to.equal('bar');
-    });
-
-    it('should handle errors in the included XML', () => {
-        registerCallbacks('path/sub.xml', '<sub foo="bar">');
-        expect(() => XmlDocument.fromString(
-            '<doc xmlns:xi="http://www.w3.org/2001/XInclude"><xi:include href="sub.xml"></xi:include></doc>',
-            { url: 'path/doc.xml', option: ParseOption.XML_PARSE_XINCLUDE },
-        )).to.throw(
-            XmlParseError,
-            'Premature end of data in tag sub line 1\ncould not load path/sub.xml, and no fallback was found',
-        ).with.deep.property('details', [{
-            message: 'Premature end of data in tag sub line 1\n',
-            file: 'path/sub.xml',
-            line: 1,
-            col: 16,
-        }, {
-            message: 'could not load path/sub.xml, and no fallback was found\n',
-            file: 'path/doc.xml',
-            line: 1,
-            col: 0,
-        }]);
+        const inc = doc.root.firstChild as XmlElement;
+        expect(inc.name).to.equal('include');
+        expect(inc.prefix).to.equal('xi');
+        expect(inc.attr('href')?.content).to.equal('sub.xml');
     });
 });

--- a/test/crossplatform/utils.spec.mts
+++ b/test/crossplatform/utils.spec.mts
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 import {
     closeBuffer,
     openBuffer,
-    ParseOption,
     readBuffer,
     XmlBufferInputProvider,
     xmlCleanupInputProvider,
@@ -54,7 +53,8 @@ describe('buffer reader', () => {
   <xi:include href="a.xml"/>
   <xi:include href="b.xml"/>
 </docs>
-`, { option: ParseOption.XML_PARSE_XINCLUDE });
+`);
+        doc.processXInclude();
 
         expect(doc.get('/docs/a')).to.not.be.null;
         expect(doc.get('/docs/b')).to.not.be.null;
@@ -70,7 +70,8 @@ describe('buffer reader', () => {
 <docs xmlns:xi="http://www.w3.org/2001/XInclude">
   <xi:include href="a.xml"/>
 </docs>
-`, { option: ParseOption.XML_PARSE_XINCLUDE });
+`);
+        doc.processXInclude();
 
         expect(doc.get('/docs/a')).to.not.be.null;
     });
@@ -82,12 +83,13 @@ describe('buffer reader', () => {
         buffers.removeBuffer('a.xml');
         xmlRegisterInputProvider(buffers);
 
-        expect(() => XmlDocument.fromString(`\
+        using doc = XmlDocument.fromString(`\
 <?xml version="1.0"?>
 <docs xmlns:xi="http://www.w3.org/2001/XInclude">
   <xi:include href="a.xml"/>
 </docs>
-`, { option: ParseOption.XML_PARSE_XINCLUDE })).to.throw();
+`);
+        expect(() => doc.processXInclude()).to.throw();
     });
 });
 

--- a/test/crossplatform/virtualIO.spec.mts
+++ b/test/crossplatform/virtualIO.spec.mts
@@ -1,5 +1,4 @@
 import {
-    ParseOption,
     xmlCleanupInputProvider,
     XmlDocument,
     XmlParseError,
@@ -33,10 +32,11 @@ describe('Virtual IO', () => {
             },
         });
 
-        expect(() => XmlDocument.fromString(
+        using doc = XmlDocument.fromString(
             '<doc xmlns:xi="http://www.w3.org/2001/XInclude"><xi:include href="sub.xml"></xi:include></doc>',
-            { url: 'path/doc.xml', option: ParseOption.XML_PARSE_XINCLUDE },
-        )).to.throw(
+            { url: 'path/doc.xml' },
+        );
+        expect(() => doc.processXInclude()).to.throw(
             XmlParseError,
             'failed to load "path/sub.xml": No such file or directory\ncould not load path/sub.xml, and no fallback was found\n',
         ).with.deep.property('details', [{
@@ -72,10 +72,11 @@ describe('Virtual IO', () => {
             },
         });
 
-        expect(() => XmlDocument.fromString(
+        using doc = XmlDocument.fromString(
             '<doc xmlns:xi="http://www.w3.org/2001/XInclude"><xi:include href="sub.xml"></xi:include></doc>',
-            { url: 'path/doc.xml', option: ParseOption.XML_PARSE_XINCLUDE },
-        )).to.throw(
+            { url: 'path/doc.xml' },
+        );
+        expect(() => doc.processXInclude()).to.throw(
             XmlParseError,
             'failed to load "path/sub.xml": No such file or directory\ncould not load path/sub.xml, and no fallback was found\n',
         ).with.deep.property('details', [{
@@ -113,10 +114,11 @@ describe('Virtual IO', () => {
             },
         });
 
-        expect(() => XmlDocument.fromString(
+        using doc = XmlDocument.fromString(
             '<doc xmlns:xi="http://www.w3.org/2001/XInclude"><xi:include href="sub.xml"></xi:include></doc>',
-            { url: 'path/doc.xml', option: ParseOption.XML_PARSE_XINCLUDE },
-        )).to.throw(
+            { url: 'path/doc.xml' },
+        );
+        expect(() => doc.processXInclude()).to.throw(
             XmlParseError,
             'Unknown IO error\nDocument is empty\ncould not load path/sub.xml, and no fallback was found\n',
         ).with.deep.property('details', [{

--- a/test/testfiles/initialization🚀.test.js
+++ b/test/testfiles/initialization🚀.test.js
@@ -6,7 +6,6 @@ const libPath = fs.existsSync('./lib/index.mjs')
 
 import(`${libPath}/lib/nodejs.mjs`).then(({ xmlRegisterFsInputProviders }) => {
     import(`${libPath}/lib/index.mjs`).then(({
-        ParseOption,
         xmlCleanupInputProvider,
         XmlDocument,
         XsdValidator,
@@ -17,8 +16,9 @@ import(`${libPath}/lib/nodejs.mjs`).then(({ xmlRegisterFsInputProviders }) => {
         const validator = XsdValidator.fromDoc(schemaDoc);
         const doc = XmlDocument.fromBuffer(
             fs.readFileSync('test/testfiles/book.xml'),
-            { url: 'test/testfiles/book.xml', option: ParseOption.XML_PARSE_XINCLUDE },
+            { url: 'test/testfiles/book.xml' },
         );
+        doc.processXInclude();
         try {
             validator.validate(doc);
         } finally {


### PR DESCRIPTION
XInclude processing is now only available through explicit processXInclude() method calls. The XML_PARSE_XINCLUDE parse option is deprecated and no longer triggers automatic processing during parsing.
