### PR TITLE
Map XPath runtime evaluation failure to `XmlXPathError`

### DIFF
--- a/src/nodes.mts
+++ b/src/nodes.mts
@@ -5,7 +5,9 @@ import {
     xmlAddNextSibling,
     xmlAddPrevSibling,
     XmlError,
+    XmlErrorStruct,
     xmlFreeNode,
+    xmlGetLastError,
     xmlGetNsList,
     xmlHasNsProp,
     XmlNamedNodeStruct,
@@ -22,6 +24,7 @@ import {
     XmlNodeType,
     XmlNsStruct,
     xmlRemoveProp,
+    xmlResetLastError,
     xmlSaveClose,
     xmlSaveOption,
     xmlSaveSetIndentString,
@@ -40,7 +43,7 @@ import {
     xmlXPathSetContextNode,
 } from './libxml2.mjs';
 import { XmlStringOutputBufferHandler } from './utils.mjs';
-import { XmlXPath } from './xpath.mjs';
+import { XmlXPath, XmlXPathError } from './xpath.mjs';
 
 import type { SubtreeC14NOptions } from './c14n.mjs';
 import type {
@@ -59,8 +62,22 @@ function compiledXPathEval(nodePtr: XmlNodePtr, xpath: XmlXPath) {
             });
     }
     xmlXPathSetContextNode(nodePtr, context);
+    xmlResetLastError();
     const xpathObj = xmlXPathCompiledEval(xpath._ptr, context);
     xmlXPathFreeContext(context);
+    if (xpathObj === 0) {
+        // xmlXPathCompiledEval returns NULL on a runtime evaluation failure, e.g. an
+        // undefined namespace prefix, variable, or function. Forward libxml2's own
+        // diagnostic instead of letting the null pointer surface downstream as a
+        // generic 'Access with null pointer' error. libxml2 exposes no XPath-context
+        // error handler to bind, so read the global last-error (cleared above) rather
+        // than a context-scoped collector as parse()/XInclude do.
+        const lastError = xmlGetLastError();
+        const detail = lastError === 0 ? '' : `: ${XmlErrorStruct.message(lastError).trim()}`;
+        throw new XmlXPathError(
+            `Failed to evaluate XPath expression '${xpath.toString()}'${detail}`,
+        );
+    }
     return xpathObj;
 }
 

--- a/src/xpath.mts
+++ b/src/xpath.mts
@@ -8,7 +8,7 @@ import {
 import type { XmlXPathCompExprPtr } from './libxml2raw.mjs';
 
 /**
- * An exception class for XPath compilation errors.
+ * An exception class for XPath compilation or evaluation errors.
  */
 export class XmlXPathError extends XmlError {}
 

--- a/test/crossplatform/nodes.spec.mts
+++ b/test/crossplatform/nodes.spec.mts
@@ -92,6 +92,13 @@ describe('XmlNode', () => {
                 'XPath selector must return a node set',
             );
         });
+
+        it('should throw XmlXPathError for an undefined namespace prefix', () => {
+            // 'x' was never registered; libxml2 fails evaluation and returns NULL.
+            // This must surface as an XmlXPathError forwarding libxml2's real
+            // diagnostic, not a generic 'Access with null pointer' internal error.
+            expect(() => doc.get('//x:y')).to.throw(XmlXPathError, 'Undefined namespace prefix: x');
+        });
     });
 
     describe('doc property', () => {
@@ -502,6 +509,19 @@ describe('XmlNode', () => {
 
         it('should throw XmlXPathError for null XPath expressions', () => {
             expect(() => doc.root.eval(null!)).to.throw('Failed to compile XPath expression: null');
+        });
+
+        // A runtime evaluation failure makes xmlXPathCompiledEval return NULL. Each of
+        // these previously surfaced as a generic 'Access with null pointer' error; they
+        // must now throw XmlXPathError forwarding libxml2's real diagnostic.
+        [
+            ['undefined namespace prefix', '//x:y', 'Undefined namespace prefix: x'],
+            ['undefined variable', '$undefinedVar', 'Undefined variable: undefinedVar'],
+            ['unregistered function', 'nope()', 'Unregistered function: nope'],
+        ].forEach(([cause, xpath, message]) => {
+            it(`should throw XmlXPathError with the real cause for an ${cause}`, () => {
+                expect(() => doc.root.eval(xpath)).to.throw(XmlXPathError, message);
+            });
         });
 
         it('should handle complex numeric expressions', () => {


### PR DESCRIPTION
Closes #162.

## Fix

In `compiledXPathEval` (`src/nodes.mts`), reset the last error before evaluation and, when the result is NULL, throw `XmlXPathError` forwarding libxml2's own diagnostic:

```
XmlXPathError: Failed to evaluate XPath expression '//x:y': Undefined namespace prefix: x
```

- Uses the already-exported `xmlGetLastError`/`xmlResetLastError` + `XmlErrorStruct.message`.
- Placed in `compiledXPathEval`, the single chokepoint both `get()` and `eval()` (and `find()`) route through.
- libxml2 exposes no XPath-context error handler to bind, so this reads the global last-error (cleared immediately before the call) rather than the context-scoped collector that `parse()`/XInclude use.

## Note

`XmlXPathError` carries only a `message`, whereas parse/DTD/XInclude failures throw `XmlLibError` with structured `details: ErrorDetail[]`. Making XPath errors carry `details` too is feasible (the last-error pointer exposes level/line/col/file via `XmlErrorStruct`), but it's a public error-API change that should also cover `XmlXPath.compile` for consistency.