### PR TITLE
Free input provider callbacks on cleanup

### DIFF
--- a/binding/exported-runtime-functions.txt
+++ b/binding/exported-runtime-functions.txt
@@ -4,4 +4,5 @@ UTF8ToString
 addFunction
 getValue
 lengthBytesUTF8
+removeFunction
 stringToUTF8

--- a/src/libxml2.mts
+++ b/src/libxml2.mts
@@ -460,6 +460,10 @@ export interface XmlInputProvider {
     close: (fd: Pointer) => boolean;
 }
 
+// Function-table entries of the registered callbacks. addFunction never reuses an entry
+// until it is removed, so they are tracked here and released by xmlCleanupInputProvider.
+const inputCallbackFuncs: Pointer[] = [];
+
 /**
  * Register the callbacks from the provider to the system.
  *
@@ -490,17 +494,30 @@ export function xmlRegisterInputProvider(
         (fd: Pointer) => (provider.close(fd) ? 0 : -1),
         'ii',
     );
+    const funcs = [matchFunc, openFunc, readFunc, closeFunc];
 
     const res = libxml2._xmlRegisterInputCallbacks(matchFunc, openFunc, readFunc, closeFunc);
-    return res >= 0;
+    if (res < 0) {
+        // libxml2 didn't take the callbacks, its callback table is full.
+        funcs.forEach((func) => libxml2.removeFunction(func));
+        return false;
+    }
+    inputCallbackFuncs.push(...funcs);
+    return true;
 }
 
 /**
  * Remove and cleanup all registered input providers.
+ *
+ * This releases the wasm function-table entries of the registered callbacks, so it must
+ * not be called from a provider callback: libxml2 keeps calling the read and close
+ * callbacks of the files it still has open.
  * @alpha
  */
 export function xmlCleanupInputProvider(): void {
     libxml2._xmlCleanupInputCallbacks();
+    inputCallbackFuncs.forEach((func) => libxml2.removeFunction(func));
+    inputCallbackFuncs.length = 0;
 }
 
 /**

--- a/src/libxml2raw.d.mts
+++ b/src/libxml2raw.d.mts
@@ -184,6 +184,7 @@ export class LibXml2 {
     addFunction(func: Function, sig: string): Pointer;
     getValue(ptr: Pointer, type: string): number;
     lengthBytesUTF8(str: string): number;
+    removeFunction(func: Pointer): void;
     stringToUTF8(str: string, outPtr: CString, maxBytesToWrite: number): CString;
 }
 

--- a/test/crossplatform/virtualIO.spec.mts
+++ b/test/crossplatform/virtualIO.spec.mts
@@ -2,11 +2,19 @@ import { assert, expect } from 'chai';
 import sinon from 'sinon';
 
 import {
+    XmlBufferInputProvider,
     xmlCleanupInputProvider,
     XmlDocument,
     XmlParseError,
     xmlRegisterInputProvider,
 } from '@libxml2-wasm/lib/index.mjs';
+// addFunction is an @internal export, stripped from the public .d.mts.
+// eslint-disable-next-line import-x/no-namespace
+import * as internal from '@libxml2-wasm/lib/libxml2.mjs';
+
+const { addFunction } = internal as unknown as {
+    addFunction: (func: () => number, sig: string) => number;
+};
 
 describe('Virtual IO', () => {
     afterEach(() => {
@@ -191,5 +199,95 @@ describe('Virtual IO', () => {
         doc.processXInclude();
 
         expect(close.calledWith(44)).to.be.true;
+    });
+});
+
+describe('Virtual IO resource management', () => {
+    // addFunction hands out the next free function-table index, so probing it around an
+    // operation shows how many entries that operation stranded.
+    const probe = (): number => addFunction(() => 0, 'i');
+
+    afterEach(() => {
+        xmlCleanupInputProvider();
+    });
+
+    it('should reclaim wasm function-table entries on cleanup', () => {
+        // Each register allocates four entries. Cleanup has to release them for reuse, which
+        // takes more than one cycle to observe: a single freed entry is handed straight back
+        // to the next probe. Over many cycles the index stays put, while a leak adds four
+        // entries per cycle.
+        const cycles = 20;
+
+        const before = probe();
+        for (let i = 0; i < cycles; i += 1) {
+            xmlRegisterInputProvider(new XmlBufferInputProvider({}));
+            xmlCleanupInputProvider();
+        }
+        const growth = probe() - before;
+
+        expect(growth, `function table grew by ${growth} over ${cycles} register/cleanup cycles`)
+            .to.be.at.most(8);
+    });
+
+    it('should refuse to register when libxml2 has no callback slot left', () => {
+        // libxml2's input callback table has a fixed size, so registering without cleanup is
+        // refused at some point. A refused registration must release the entries it allocated.
+        const results: boolean[] = [];
+        for (let i = 0; i < 16; i += 1) {
+            results.push(xmlRegisterInputProvider(new XmlBufferInputProvider({})));
+        }
+        expect(results[0], 'the first registration should succeed').to.be.true;
+        expect(results, 'registration should be refused once the table is full')
+            .to.include(false);
+
+        const refusals = 20;
+        const before = probe();
+        for (let i = 0; i < refusals; i += 1) {
+            expect(xmlRegisterInputProvider(new XmlBufferInputProvider({}))).to.be.false;
+        }
+        const growth = probe() - before;
+        expect(growth, `${refusals} refused registrations grew the table by ${growth}`)
+            .to.be.at.most(8);
+
+        xmlCleanupInputProvider();
+        expect(xmlRegisterInputProvider(new XmlBufferInputProvider({})), 'cleanup frees the table')
+            .to.be.true;
+    });
+
+    it('should release the provider and its buffers on cleanup', async () => {
+        const settle = async (): Promise<void> => {
+            for (let i = 0; i < 3; i += 1) {
+                (global as any).gc();
+                // eslint-disable-next-line no-await-in-loop
+                await new Promise((resolve) => {
+                    setTimeout(resolve, 0);
+                });
+            }
+        };
+
+        const collectedAfter = async (
+            act: (provider: XmlBufferInputProvider) => void,
+        ): Promise<boolean> => {
+            let provider: XmlBufferInputProvider | null = new XmlBufferInputProvider({
+                'part.xml': new Uint8Array(1 << 20),
+            });
+            const ref = new WeakRef(provider);
+            act(provider);
+            provider = null;
+            await settle();
+            return ref.deref() === undefined;
+        };
+
+        // Control case: proves the WeakRef + gc probe really observes collection, so a
+        // positive result below cannot be a false positive.
+        expect(await collectedAfter(() => {}), 'unregistered provider should be collectible')
+            .to.be.true;
+        expect(
+            await collectedAfter((provider) => {
+                xmlRegisterInputProvider(provider);
+                xmlCleanupInputProvider();
+            }),
+            'cleanup must release the provider and its buffers',
+        ).to.be.true;
     });
 });


### PR DESCRIPTION
Closes #166

## Fix

`xmlRegisterInputProvider` adds four wasm function-table entries per call, one per
callback closure (`match`/`open`/`read`/`close`), and `xmlCleanupInputProvider`
reclaimed none of them. `addFunction` cannot reuse an entry until `removeFunction`
releases it, so every register grew the table by four permanently and pinned the
provider, and any buffers it captured, for the process lifetime.

- `binding/exported-runtime-functions.txt` exports `removeFunction`
  (`-s ALLOW_TABLE_GROWTH=1` is already set, so no other emcc change is needed).
- `src/libxml2.mts` tracks the entries of each registration and releases them in
  cleanup. libxml2 keeps owning the callback stack and its precedence, and the
  provider's file descriptors still pass straight through.