### PR TITLE
Add streaming XML parsing with SAX2 callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ this library requires the minimum version of the following environments,
 
 # Features
 - Parsing & Querying
+- Streaming (SAX push parsing)
 - Validating
 - Modifying
 - Serializing

--- a/binding/exported-functions.txt
+++ b/binding/exported-functions.txt
@@ -5,9 +5,12 @@ _xmlAddNextSibling
 _xmlAddPrevSibling
 _xmlC14NExecute
 _xmlCleanupInputCallbacks
+_xmlCreatePushParserCtxt
+_xmlCtxtGetDocument
 _xmlCtxtParseDtd
 _xmlCtxtReadMemory
 _xmlCtxtSetErrorHandler
+_xmlCtxtSetOptions
 _xmlCtxtValidateDtd
 _xmlDocGetRootElement
 _xmlDocSetRootElement
@@ -34,6 +37,7 @@ _xmlNodeGetContent
 _xmlNodeSetContentLen
 _xmlOutputBufferClose
 _xmlOutputBufferCreateIO
+_xmlParseChunk
 _xmlRegisterInputCallbacks
 _xmlRelaxNGFree
 _xmlRelaxNGFreeParserCtxt
@@ -65,6 +69,7 @@ _xmlSearchNs
 _xmlSetNs
 _xmlSetNsProp
 _xmlSetWinPathEnabled
+_xmlStopParser
 _xmlUnlinkNode
 _xmlXIncludeFreeContext
 _xmlXIncludeNewContext

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,7 @@ this library requires the minimum version of the following environments,
 
 # Features
 - Parsing & Querying
+- Streaming (SAX push parsing)
 - Validating
 - Modifying
 - Serializing

--- a/docs/sax.md
+++ b/docs/sax.md
@@ -1,0 +1,203 @@
+---
+title: Streaming with SAX
+---
+
+# Streaming XML with the SAX Push Parser
+
+{@link libxml2-wasm!XmlSaxParser | `XmlSaxParser`} exposes libxml2's push parser together with its SAX2 callback interface.
+Instead of building an {@link libxml2-wasm!XmlDocument | `XmlDocument`} in memory,
+the parser reports the content of the document through callbacks while it is being fed,
+chunk by chunk.
+Memory usage therefore does not grow proportionally with the document size,
+which makes it the right tool for documents that are too large to hold as a DOM tree.
+
+```js
+import fs from 'node:fs';
+import { XmlSaxParser } from 'libxml2-wasm';
+
+const decoder = new TextDecoder();
+let inTitle = false;
+let title = '';
+using parser = XmlSaxParser.create({
+    startElementNs(localName) { inTitle = localName === 'title'; },
+    endElementNs() { inTitle = false; },
+    characters(data) {
+        if (inTitle) title += decoder.decode(data, { stream: true });
+    },
+});
+const stream = fs.createReadStream('doc.xml');
+for await (const chunk of stream) {
+    parser.push(chunk);
+}
+parser.finish();
+```
+
+All callbacks of the {@link libxml2-wasm!XmlSaxHandler | `XmlSaxHandler`} are optional;
+events without a callback are skipped without even crossing the WebAssembly boundary.
+The set of reported events is fixed when the parser is created,
+but the callback for a reported event is looked up on the handler object at every delivery:
+adding a callback that was absent at creation does not enable its event,
+while replacing or removing one that was present takes effect at once.
+
+Callbacks run while libxml2 is parsing, on top of its own frames.
+{@link libxml2-wasm!XmlSaxParser.stop | `stop`} is therefore the only method
+that may be called on the parser from within a callback;
+`push`, `finish` and `dispose` throw an
+{@link libxml2-wasm!XmlError | `XmlError`} instead of corrupting the parse.
+
+# Feeding the Parser
+
+{@link libxml2-wasm!XmlSaxParser.push | `push`} accepts raw bytes (`Uint8Array`), never pre-decoded strings;
+a Node.js `Buffer` is a `Uint8Array` and is accepted as-is.
+The chunks may be split at arbitrary byte positions:
+tags, entity references and even multi-byte characters may be cut in half between two pushes.
+Chunk boundaries are also unrelated to event boundaries -
+a single `push` may deliver zero, one or many callbacks,
+and one text node may span several pushes.
+The parser detects the encoding of the document itself, from its BOM or XML declaration,
+and always delivers UTF-8 data to the callbacks.
+
+Call {@link libxml2-wasm!XmlSaxParser.finish | `finish`} after the last chunk;
+it processes pending data, invokes `endDocument`,
+and reports the errors an incomplete document would otherwise hide.
+`endDocument` is delivered for a truncated document too, right before the error is thrown,
+so it marks the end of the events rather than a successful parse -
+only `finish` returning without throwing does.
+
+# Character Data
+
+The `characters` and `cdataBlock` callbacks receive their data as a `Uint8Array` of UTF-8 bytes.
+The array is a view into the WebAssembly memory and is **valid only during the callback** -
+and only until the WebAssembly memory grows:
+calling into any API of this library, even on another document or parser,
+may grow the memory and silently detach the view.
+Copy the bytes (for example with `data.slice()`) if they need to be retained,
+or before the callback calls into the library.
+
+libxml2 may deliver one text node as several consecutive callbacks,
+and there is no guarantee that the split falls on a UTF-8 character boundary.
+Decode the concatenated bytes, or use a streaming `TextDecoder`:
+
+```js
+const decoder = new TextDecoder();
+let text = '';
+const parser = XmlSaxParser.create({
+    characters(data) { text += decoder.decode(data, { stream: true }); },
+});
+```
+
+Passing bytes instead of strings lets the application decode only what it needs:
+skipping a node with hundreds of megabytes of embedded base64 content costs
+no more than reading `data.length`,
+without any string allocation.
+Element and attribute names, attribute values, comments and processing instructions
+are small, so they are delivered as JavaScript strings.
+
+# Entities
+
+Predefined entities (`&amp;` …), character references (`&#xA9;` …) and
+entities declared in the internal DTD subset are substituted in element content,
+and their replacement text is reported through the regular callbacks:
+`characters` for character data and,
+should the entity contain markup, the element callbacks for that markup.
+
+External entities follow libxml2's usual rules, shared with DOM parsing:
+nothing is loaded by default - the WebAssembly module has no I/O of its own.
+When {@link libxml2-wasm!ParseOption.XML_PARSE_NOENT | `XML_PARSE_NOENT`} is set,
+libxml2 attempts to load external entities through the registered
+[Virtual IO input providers](io.md#virtualio-and-xinclude-experimental);
+set {@link libxml2-wasm!ParseOption.XML_PARSE_NO_XXE | `XML_PARSE_NO_XXE`}
+to forbid that for untrusted documents.
+The external DTD subset itself is never loaded -
+{@link libxml2-wasm!ParseOption.XML_PARSE_DTDLOAD | `XML_PARSE_DTDLOAD`} has no effect here -
+so entity declarations are only picked up from the internal subset.
+
+Two quirks are inherited from libxml2's SAX interface, both in **attribute** values:
+an ampersand - however it is written, `&amp;` or `&#38;` -
+is reported as the character reference `&#38;`,
+to protect a later re-expansion against double substitution,
+and a reference to an entity declared in the DTD is passed through
+literally (`&e;`), not substituted.
+Set {@link libxml2-wasm!ParseOption.XML_PARSE_NOENT | `XML_PARSE_NOENT`}
+to receive fully substituted attribute values instead:
+
+```xml
+<!DOCTYPE doc [<!ENTITY e "value">]>
+<doc a="x&amp;y" b="&e;"/>
+```
+
+`a` is reported as `x&#38;y` and `b` as `&e;`;
+with `XML_PARSE_NOENT` they are `x&y` and `value`.
+
+# Errors
+
+{@link libxml2-wasm!XmlSaxParser.push | `push`} throws an
+{@link libxml2-wasm!XmlParseError | `XmlParseError`} as soon as a chunk makes the document unparsable,
+and {@link libxml2-wasm!XmlSaxParser.finish | `finish`} additionally fails on
+error-level diagnostics (for example namespace errors), like DOM parsing does.
+Warning-level diagnostics never interrupt parsing;
+they are collected in {@link libxml2-wasm!XmlSaxParser.warnings | `warnings`}.
+{@link libxml2-wasm!XmlSaxParser.stop | `stop`} ends parsing before `finish` can raise that
+error, so error-level diagnostics collected up to that point are only available through
+{@link libxml2-wasm!XmlSaxParser.errors | `errors`}.
+
+# Parser Options and Large Content
+
+Plain character data is streamed through `characters` incrementally,
+so a text node of any size can be processed without special options.
+However, libxml2 buffers a few constructs completely before reporting them -
+CDATA sections in particular - and limits them to 10MB.
+Set {@link libxml2-wasm!ParseOption.XML_PARSE_HUGE | `XML_PARSE_HUGE`} to lift this limit:
+
+```js
+import { ParseOption, XmlSaxParser } from 'libxml2-wasm';
+
+const parser = XmlSaxParser.create(handler, { option: ParseOption.XML_PARSE_HUGE });
+```
+
+{@link libxml2-wasm!ParseOption.XML_PARSE_DTDVALID | `XML_PARSE_DTDVALID`} is rejected by
+`create`: libxml2 validates against the document tree, which this parser deliberately does not
+build, so the option would silently accept invalid documents.
+Default attributes declared in the internal DTD subset are added to `startElementNs`'s
+`attributes` array only when
+{@link libxml2-wasm!ParseOption.XML_PARSE_DTDATTR | `XML_PARSE_DTDATTR`} is set,
+matching DOM parsing; otherwise they are omitted.
+As noted above, the option's implied `XML_PARSE_DTDLOAD` has no effect on the push parser,
+so this only applies to defaults declared in the internal subset.
+
+The options that {@link libxml2-wasm!ParseOption | `ParseOption`} documents as
+not supported by the push parser cannot be relied on here either.
+{@link libxml2-wasm!ParseOption.XML_PARSE_NOBLANKS | `XML_PARSE_NOBLANKS`} has no effect.
+{@link libxml2-wasm!ParseOption.XML_PARSE_RECOVER | `XML_PARSE_RECOVER`} does change what is
+reported - libxml2 keeps parsing past a fatal error, so the events of the chunk being pushed
+run to its end and the thrown error carries every diagnostic instead of the first -
+but the call still throws and the parser still accepts no further input,
+so it cannot be used to read a broken document to its end.
+
+# Stopping Early
+
+{@link libxml2-wasm!XmlSaxParser.stop | `stop`} terminates parsing without raising an error,
+for example when the interesting part of the document has already been seen.
+It may be called from within a handler callback;
+the `push` call being processed returns normally and no further events are delivered.
+Release the parser once that `push` has returned, not from the callback itself.
+
+A stopped parser accepts nothing further, `finish` included, so a feeding loop has to
+leave on {@link libxml2-wasm!XmlSaxParser.terminated | `terminated`}:
+
+```js
+using parser = XmlSaxParser.create(handler);
+for await (const chunk of stream) {
+    if (parser.terminated) break;
+    parser.push(chunk);
+}
+if (!parser.terminated) parser.finish();
+```
+
+# Memory Management
+
+Like all wrapper objects owning libxml2 memory,
+the parser must be released with {@link libxml2-wasm!disposable.XmlDisposable#dispose | `dispose`},
+or by declaring it with `using`.
+Disposing is required whether parsing completed, failed, or was stopped -
+see [Memory Management](mem.md).

--- a/src/document.mts
+++ b/src/document.mts
@@ -3,6 +3,7 @@ import { disposeBy, XmlDisposable } from './disposable.mjs';
 import { XmlDtd } from './dtd.mjs';
 import {
     error,
+    XML_ERR_ERROR,
     xmlCtxtSetErrorHandler,
     xmlDocGetRootElement,
     xmlDocSetRootElement,
@@ -212,8 +213,19 @@ export interface ParseOptions {
 export class XmlParseError extends XmlLibError {
 }
 
-/** libxml2 xmlErrorLevel: diagnostics at this severity or above are failures. */
-const XML_ERR_ERROR = 2;
+/**
+ * Build the {@link XmlParseError} for a failed parse from the diagnostics
+ * it collected.
+ * @internal
+ */
+export function buildParseError(details: ErrorDetail[]): XmlParseError {
+    return new XmlParseError(
+        details.length > 0
+            ? details.map((d) => d.message).join('')
+            : 'Failed to parse XML', // no diagnostics, usually invalid input
+        details,
+    );
+}
 
 function parse<Input>(
     parser: (
@@ -250,12 +262,7 @@ function parse<Input>(
                 // discarded; free it here since no wrapper/finalizer will own it.
                 xmlFreeDoc(xml);
             }
-            throw new XmlParseError(
-                errDetails.length > 0
-                    ? errDetails.map((d) => d.message).join('')
-                    : 'Failed to parse XML', // no diagnostics, usually invalid input
-                errDetails,
-            );
+            throw buildParseError(errDetails);
         }
         // Every diagnostic here is non-fatal (a warning); surface it on the document
         // before the storage slot is freed below.
@@ -532,6 +539,8 @@ export class XmlDocument extends XmlDisposable<XmlDocument> {
         try {
             const ret = xmlXIncludeProcessNode(xinc, this._ptr);
             if (ret < 0) {
+                // not buildParseError: its fallback message is about parsing,
+                // and XInclude failures always carry their own diagnostics
                 const errDetails = error.storage.get(errIndex);
                 throw new XmlParseError(errDetails.map((d) => d.message).join(''), errDetails);
             }

--- a/src/index.mts
+++ b/src/index.mts
@@ -32,6 +32,8 @@ export type {
     SaveOptions,
     XmlInputProvider,
     XmlOutputBufferHandler,
+    XmlSaxAttribute,
+    XmlSaxHandler,
 } from './libxml2.mjs';
 export {
     xmlCleanupInputProvider,
@@ -39,6 +41,7 @@ export {
     XmlLibError,
     xmlRegisterInputProvider,
 } from './libxml2.mjs';
+export { XmlSaxParser } from './sax.mjs';
 export { XmlDtd } from './dtd.mjs';
 export {
     DtdValidator,

--- a/src/libxml2.mts
+++ b/src/libxml2.mts
@@ -68,6 +68,12 @@ export interface ErrorDetail {
 }
 
 /**
+ * libxml2 xmlErrorLevel: diagnostics at this severity or above are failures.
+ * @internal
+ */
+export const XML_ERR_ERROR = 2;
+
+/**
  * An exception class represents the error in libxml2.
  */
 export class XmlLibError extends XmlError {
@@ -127,6 +133,12 @@ function withCString<R>(str: Uint8Array, process: (buf: number, len: number) => 
     }
 
     const buf = libxml2._malloc(str.length + 1);
+    // _malloc returns 0 instead of aborting when the memory cannot grow
+    // anymore; writing there would silently corrupt the module's low memory
+    /* c8 ignore next 3, needs ~2GB of allocations to trigger */
+    if (!buf) {
+        throw new XmlError(`Failed to allocate ${str.length + 1} bytes in the WebAssembly memory`);
+    }
     libxml2.HEAPU8.set(str, buf);
     libxml2.HEAPU8[buf + str.length] = 0;
     const ret = process(buf, str.length);
@@ -504,6 +516,452 @@ export function xmlCleanupInputProvider(): void {
 }
 
 /**
+ * An attribute of an element, reported by {@link XmlSaxHandler#startElementNs}.
+ *
+ * @see {@link XmlSaxHandler}
+ */
+export interface XmlSaxAttribute {
+    /**
+     * The local name of the attribute, without the namespace prefix.
+     */
+    localName: string;
+
+    /**
+     * The namespace prefix of the attribute, or `null` if it has none.
+     */
+    prefix: string | null;
+
+    /**
+     * The namespace URI of the attribute, or `null` if it has none.
+     */
+    namespaceUri: string | null;
+
+    /**
+     * The attribute value.
+     *
+     * Character references and predefined entities are already substituted,
+     * with two exceptions mirroring libxml2's SAX behavior, both lifted by
+     * {@link ParseOption.XML_PARSE_NOENT | XML_PARSE_NOENT}:
+     * an ampersand - however it is written, `&amp;` or `&#38;` -
+     * is reported as the character reference `&#38;`,
+     * and a reference to an entity declared in the DTD is passed through
+     * literally (`&name;`), not substituted.
+     */
+    value: string;
+}
+
+/**
+ * SAX callbacks invoked by an {@link XmlSaxParser} while it parses the document.
+ *
+ * All callbacks are optional; events without a callback are skipped without
+ * crossing the WebAssembly boundary.
+ * The set of reported events is fixed when the parser is created,
+ * but the callback for a reported event is looked up on the handler at
+ * every delivery: adding a callback that was absent at creation does not
+ * enable its event, while replacing or removing one that was present
+ * takes effect at once.
+ *
+ * Note that libxml2 delivers all names and character data in UTF-8,
+ * regardless of the encoding of the input document.
+ *
+ * @see {@link XmlSaxParser}
+ */
+export interface XmlSaxHandler {
+    /**
+     * Called when the parser starts processing the document,
+     * before any other callback.
+     */
+    startDocument?: () => void;
+
+    /**
+     * Called at the end of the document,
+     * when {@link XmlSaxParser#finish} processed the last pending events.
+     */
+    endDocument?: () => void;
+
+    /**
+     * Called after a start tag, with its namespace information.
+     *
+     * @param localName The local name of the element, without the namespace prefix
+     * @param prefix The namespace prefix of the element, or `null` if it has none
+     * @param namespaceUri The namespace URI of the element, or `null` if it has none
+     * @param namespaces The namespaces declared on this element,
+     * as `[prefix, uri]` pairs; the prefix is `null` for a default namespace declaration
+     * @param attributes The attributes of the element; default attributes
+     * declared in the internal DTD subset are included only when
+     * {@link ParseOption.XML_PARSE_DTDATTR} was set on the parser
+     */
+    startElementNs?: (
+        localName: string,
+        prefix: string | null,
+        namespaceUri: string | null,
+        namespaces: [prefix: string | null, uri: string][],
+        attributes: XmlSaxAttribute[],
+    ) => void;
+
+    /**
+     * Called after an end tag (or at the end of an empty element tag).
+     *
+     * @param localName The local name of the element, without the namespace prefix
+     * @param prefix The namespace prefix of the element, or `null` if it has none
+     * @param namespaceUri The namespace URI of the element, or `null` if it has none
+     */
+    endElementNs?: (
+        localName: string,
+        prefix: string | null,
+        namespaceUri: string | null,
+    ) => void;
+
+    /**
+     * Called with a run of character data.
+     *
+     * `data` holds UTF-8 encoded bytes and is a view into the WebAssembly memory:
+     * it is valid only during the callback, and only until the WebAssembly
+     * memory grows - calling into any API of this library, even on another
+     * document or parser, may grow the memory and silently detach the view.
+     * Copy the bytes (e.g. with `data.slice()`) before retaining them or
+     * calling into the library.
+     *
+     * libxml2 may deliver a single text node as many consecutive calls,
+     * and there is no guarantee that the split falls on a UTF-8 character
+     * boundary.
+     * To get the text, concatenate the bytes of consecutive calls,
+     * or decode them with a streaming `TextDecoder`
+     * (`decoder.decode(data, { stream: true })`);
+     * don't decode each chunk in isolation.
+     *
+     * @param data UTF-8 encoded character data, valid only during the callback
+     */
+    characters?: (data: Uint8Array) => void;
+
+    /**
+     * Called with the content of a CDATA section.
+     *
+     * If this callback is not set, CDATA content is reported through
+     * {@link characters} instead.
+     *
+     * `data` is subject to the same validity and splitting rules as
+     * {@link characters}.
+     *
+     * @param data UTF-8 encoded content of the CDATA section,
+     * valid only during the callback
+     */
+    cdataBlock?: (data: Uint8Array) => void;
+
+    /**
+     * Called after a comment.
+     *
+     * @param text The content of the comment
+     */
+    comment?: (text: string) => void;
+
+    /**
+     * Called after a processing instruction.
+     *
+     * @param target The target of the processing instruction
+     * @param data The data of the processing instruction,
+     * or `null` if it has none
+     */
+    processingInstruction?: (target: string, data: string | null) => void;
+}
+
+/**
+ * The JavaScript side of a push parser context.
+ * Its owner has to keep it alive for as long as the parser is used.
+ * @internal
+ */
+export interface SaxParserContext {
+    handler: XmlSaxHandler;
+    // A value thrown by a handler callback, to be rethrown after xmlParseChunk returns
+    failure?: { error: unknown };
+    // Whether XML_PARSE_DTDATTR was set at creation: libxml2 always appends
+    // DTD-defaulted attributes to the end of startElementNs's attribute
+    // array, counted separately in nb_defaulted, and expects the consumer
+    // to trim them when the option is off, the same way its own tree-building
+    // SAX2 callback does.
+    reportDtdDefaultedAttrs: boolean;
+}
+
+// Live SAX parser contexts. libxml2 invokes the SAX callbacks with the parser
+// context pointer as their first argument (the SAX user data is left NULL, so
+// ctxt->userData falls back to the context itself), which keys this map.
+// The references are weak: a handler usually refers back to its own parser -
+// that is how stop() is called - so holding one here would root the parser in
+// this module and keep it from ever being garbage collected.
+const saxParsers = new Map<XmlParserCtxtPtr, WeakRef<SaxParserContext>>();
+
+// Shared skeleton of the SAX trampolines: look up the live dispatch context,
+// suppress events after a failure, and never let a JS exception thrown by a
+// handler callback unwind through the C frames of the parser - that would
+// skip their cleanup - by stopping the parser and holding the exception
+// until xmlParseChunk returns.
+function saxCallback(
+    sig: string,
+    invoke: (context: SaxParserContext, ...args: number[]) => void,
+): Pointer {
+    return libxml2.addFunction((ctxt: XmlParserCtxtPtr, ...args: number[]) => {
+        const context = saxParsers.get(ctxt)?.deref();
+        /* c8 ignore next 3, defensive: callbacks are suppressed after a failure */
+        if (!context || context.failure) {
+            return;
+        }
+        try {
+            invoke(context, ...args);
+        } catch (err) {
+            context.failure = { error: err };
+            libxml2._xmlStopParser(ctxt);
+        }
+    }, sig);
+}
+
+const saxStartDocument = saxCallback('vi', (context) => {
+    context.handler.startDocument?.();
+});
+
+const saxEndDocument = saxCallback('vi', (context) => {
+    context.handler.endDocument?.();
+});
+
+const saxStartElementNs = saxCallback('viiiiiiiii', (
+    context,
+    localName,
+    prefix,
+    uri,
+    nbNamespaces,
+    namespaces,
+    nbAttributes,
+    nbDefaulted,
+    attributes,
+) => {
+    // the C callback stays installed when the JS one is removed mid-parse;
+    // skip the marshalling below too, not just the invocation
+    if (!context.handler.startElementNs) {
+        return;
+    }
+    // pointers are 4-byte aligned and fit in HEAP32:
+    // the memory is capped at 2GB (the ALLOW_MEMORY_GROWTH default)
+    const ptrs = libxml2.HEAP32;
+    // namespaces is an array of nbNamespaces (prefix, uri) pointer pairs
+    const nsDecls: [string | null, string][] = [];
+    for (let slot = namespaces / 4, end = slot + nbNamespaces * 2; slot < end; slot += 2) {
+        nsDecls.push([
+            nullableUTF8ToString(ptrs[slot]),
+            libxml2.UTF8ToString(ptrs[slot + 1]),
+        ]);
+    }
+    // attributes is an array of nbAttributes
+    // (localname, prefix, uri, value, end) pointer quintuplets;
+    // the value is NOT null terminated, it spans [value, end)
+    // DTD-defaulted attributes (counted in nbDefaulted) are appended after
+    // the ones actually written in the document; drop them unless the
+    // consumer asked for them, mirroring libxml2's own xmlSAX2StartElementNs
+    const reportedAttributes = context.reportDtdDefaultedAttrs
+        ? nbAttributes
+        : nbAttributes - nbDefaulted;
+    const attrs: XmlSaxAttribute[] = [];
+    for (let slot = attributes / 4, end = slot + reportedAttributes * 5; slot < end; slot += 5) {
+        const value = ptrs[slot + 3];
+        const valueEnd = ptrs[slot + 4];
+        attrs.push({
+            localName: libxml2.UTF8ToString(ptrs[slot]),
+            prefix: nullableUTF8ToString(ptrs[slot + 1]),
+            namespaceUri: nullableUTF8ToString(ptrs[slot + 2]),
+            value: valueEnd > value ? libxml2.UTF8ToString(value, valueEnd - value) : '',
+        });
+    }
+    context.handler.startElementNs(
+        libxml2.UTF8ToString(localName),
+        nullableUTF8ToString(prefix),
+        nullableUTF8ToString(uri),
+        nsDecls,
+        attrs,
+    );
+});
+
+const saxEndElementNs = saxCallback('viiii', (context, localName, prefix, uri) => {
+    context.handler.endElementNs?.(
+        libxml2.UTF8ToString(localName),
+        nullableUTF8ToString(prefix),
+        nullableUTF8ToString(uri),
+    );
+});
+
+const saxCharacters = saxCallback('viii', (context, ch, len) => {
+    context.handler.characters?.(libxml2.HEAPU8.subarray(ch, ch + len));
+});
+
+const saxCdataBlock = saxCallback('viii', (context, ch, len) => {
+    context.handler.cdataBlock?.(libxml2.HEAPU8.subarray(ch, ch + len));
+});
+
+const saxComment = saxCallback('vii', (context, text) => {
+    context.handler.comment?.(libxml2.UTF8ToString(text));
+});
+
+const saxProcessingInstruction = saxCallback('viii', (context, target, data) => {
+    context.handler.processingInstruction?.(
+        libxml2.UTF8ToString(target),
+        nullableUTF8ToString(data),
+    );
+});
+
+/**
+ * Field slots of struct xmlSAXHandler (each field is one 4-byte slot on wasm32).
+ *
+ * Pinned to the field order in the libxml2 submodule's include/libxml/parser.h:
+ *
+ *  0 internalSubset      1 isStandalone          2 hasInternalSubset
+ *  3 hasExternalSubset   4 resolveEntity         5 getEntity
+ *  6 entityDecl          7 notationDecl          8 attributeDecl
+ *  9 elementDecl        10 unparsedEntityDecl   11 setDocumentLocator
+ * 12 startDocument      13 endDocument          14 startElement
+ * 15 endElement         16 reference            17 characters
+ * 18 ignorableWhitespace 19 processingInstruction 20 comment
+ * 21 warning            22 error                23 fatalError
+ * 24 getParameterEntity 25 cdataBlock           26 externalSubset
+ * 27 initialized        28 _private             29 startElementNs
+ * 30 endElementNs       31 serror
+ */
+enum SaxHandlerSlot {
+    startDocument = 12,
+    endDocument = 13,
+    characters = 17,
+    ignorableWhitespace = 18,
+    processingInstruction = 19,
+    comment = 20,
+    cdataBlock = 25,
+    initialized = 27,
+    startElementNs = 29,
+    endElementNs = 30,
+}
+
+const SAX_HANDLER_SLOT_COUNT = 32;
+
+// Magic value in the `initialized` field enabling the SAX2 interface;
+// without it, xmlCreatePushParserCtxt copies only the SAX1-sized prefix
+// of the struct and drops startElementNs/endElementNs.
+const XML_SAX2_MAGIC = 0xDEEDBEAF;
+
+/**
+ * Create a libxml2 push parser context with SAX callbacks
+ * dispatching to `handler`.
+ *
+ * Only the struct slots for callbacks present on `handler` are populated,
+ * so skipped events never cross the WebAssembly boundary.
+ *
+ * @returns the parser context - 0 on failure - and the dispatch context that
+ * the caller has to keep alive for as long as the parser is used.
+ * @internal
+ */
+export function xmlCreatePushParserCtxt(
+    handler: XmlSaxHandler,
+    filename: string | null,
+): [XmlParserCtxtPtr, SaxParserContext] {
+    const context: SaxParserContext = { handler, reportDtdDefaultedAttrs: false };
+    const sax = libxml2._malloc(SAX_HANDLER_SLOT_COUNT * 4);
+    /* c8 ignore next 5, defensive: the allocation fails only when out of memory */
+    if (!sax) {
+        // a NULL handler would select libxml2's default, tree building one,
+        // which reports nothing and defeats the purpose of the push parser
+        return [0, context];
+    }
+    const base = sax / 4;
+    const slots = libxml2.HEAP32;
+    slots.fill(0, base, base + SAX_HANDLER_SLOT_COUNT);
+    if (handler.startDocument) {
+        slots[base + SaxHandlerSlot.startDocument] = saxStartDocument;
+    }
+    if (handler.endDocument) {
+        slots[base + SaxHandlerSlot.endDocument] = saxEndDocument;
+    }
+    if (handler.startElementNs) {
+        slots[base + SaxHandlerSlot.startElementNs] = saxStartElementNs;
+    }
+    if (handler.endElementNs) {
+        slots[base + SaxHandlerSlot.endElementNs] = saxEndElementNs;
+    }
+    if (handler.characters) {
+        slots[base + SaxHandlerSlot.characters] = saxCharacters;
+        // Deliver whitespace-only character data through the same callback;
+        // per the xmlSAXHandler docs, ignorableWhitespace should always be set
+        // to the same value as characters, otherwise the parser tries to
+        // detect "ignorable" whitespace, which is unreliable in push mode.
+        slots[base + SaxHandlerSlot.ignorableWhitespace] = saxCharacters;
+    }
+    if (handler.cdataBlock) {
+        slots[base + SaxHandlerSlot.cdataBlock] = saxCdataBlock;
+    }
+    if (handler.comment) {
+        slots[base + SaxHandlerSlot.comment] = saxComment;
+    }
+    if (handler.processingInstruction) {
+        slots[base + SaxHandlerSlot.processingInstruction] = saxProcessingInstruction;
+    }
+    slots[base + SaxHandlerSlot.initialized] = XML_SAX2_MAGIC;
+    // user data is left NULL: ctxt->userData then defaults to the context
+    // itself, which is what the shared callbacks above use as dispatch key
+    const ctxt = withStringUTF8(
+        filename,
+        (buf) => libxml2._xmlCreatePushParserCtxt(sax, 0, 0, 0, buf),
+    );
+    // the context copies the struct, it doesn't keep the pointer
+    libxml2._free(sax);
+    if (ctxt) {
+        saxParsers.set(ctxt, new WeakRef(context));
+    }
+    return [ctxt, context];
+}
+
+/**
+ * Parse a chunk of data with a push parser context.
+ *
+ * Rethrows the exception if a SAX callback of the chunk threw one.
+ *
+ * @returns the xmlParserErrors code of the parse, 0 on success.
+ * @internal
+ */
+export function xmlParseChunk(
+    ctxt: XmlParserCtxtPtr,
+    chunk: Uint8Array | null,
+    terminate: boolean,
+): number {
+    const flag = terminate ? 1 : 0;
+    let ret;
+    if (chunk) {
+        ret = withCString(chunk, (buf, len) => libxml2._xmlParseChunk(ctxt, buf, len, flag));
+    } else {
+        ret = libxml2._xmlParseChunk(ctxt, 0, 0, flag);
+    }
+    const parser = saxParsers.get(ctxt)?.deref();
+    if (parser?.failure) {
+        const { error: err } = parser.failure;
+        delete parser.failure;
+        throw err;
+    }
+    return ret;
+}
+
+/**
+ * Free a push parser context created by {@link xmlCreatePushParserCtxt}
+ * and its callback dispatch entry.
+ * @internal
+ */
+export function xmlFreeSaxParserCtxt(ctxt: XmlParserCtxtPtr): void {
+    saxParsers.delete(ctxt);
+    // Even in SAX mode, libxml2 keeps the entities declared in the internal
+    // subset in a document of its own, and releases it only when the parse
+    // runs to its end - not when it is stopped, fails or is abandoned.
+    // xmlFreeParserCtxt doesn't free it either; xmlCtxtGetDocument detaches
+    // it from the context, either handing it over or freeing it itself
+    // (after a fatal error).
+    const doc = libxml2._xmlCtxtGetDocument(ctxt);
+    if (doc) {
+        libxml2._xmlFreeDoc(doc);
+    }
+    libxml2._xmlFreeParserCtxt(ctxt);
+}
+
+/**
  * Options to be passed in the call to saving functions
  *
  * @default If not specified, `{ format: true }` will be used.
@@ -696,6 +1154,7 @@ export const xmlAddChild = libxml2._xmlAddChild;
 export const xmlAddNextSibling = libxml2._xmlAddNextSibling;
 export const xmlAddPrevSibling = libxml2._xmlAddPrevSibling;
 export const xmlCtxtSetErrorHandler = libxml2._xmlCtxtSetErrorHandler;
+export const xmlCtxtSetOptions = libxml2._xmlCtxtSetOptions;
 export const xmlCtxtValidateDtd = libxml2._xmlCtxtValidateDtd;
 export const xmlDocGetRootElement = libxml2._xmlDocGetRootElement;
 export const xmlDocSetRootElement = libxml2._xmlDocSetRootElement;
@@ -732,6 +1191,7 @@ export const xmlSchemaSetValidStructuredErrors = libxml2._xmlSchemaSetValidStruc
 export const xmlSchemaValidateDoc = libxml2._xmlSchemaValidateDoc;
 export const xmlSchemaValidateOneElement = libxml2._xmlSchemaValidateOneElement;
 export const xmlSetNs = libxml2._xmlSetNs;
+export const xmlStopParser = libxml2._xmlStopParser;
 export const xmlUnlinkNode = libxml2._xmlUnlinkNode;
 export const xmlXIncludeFreeContext = libxml2._xmlXIncludeFreeContext;
 export const xmlXIncludeNewContext = libxml2._xmlXIncludeNewContext;

--- a/src/libxml2.mts
+++ b/src/libxml2.mts
@@ -133,12 +133,6 @@ function withCString<R>(str: Uint8Array, process: (buf: number, len: number) => 
     }
 
     const buf = libxml2._malloc(str.length + 1);
-    // _malloc returns 0 instead of aborting when the memory cannot grow
-    // anymore; writing there would silently corrupt the module's low memory
-    /* c8 ignore next 3, needs ~2GB of allocations to trigger */
-    if (!buf) {
-        throw new XmlError(`Failed to allocate ${str.length + 1} bytes in the WebAssembly memory`);
-    }
     libxml2.HEAPU8.set(str, buf);
     libxml2.HEAPU8[buf + str.length] = 0;
     const ret = process(buf, str.length);

--- a/src/libxml2raw.d.mts
+++ b/src/libxml2raw.d.mts
@@ -40,6 +40,14 @@ export class LibXml2 {
     _xmlAddNextSibling(prev: XmlNodePtr, cur: XmlNodePtr): XmlNodePtr;
     _xmlAddPrevSibling(next: XmlNodePtr, cur: XmlNodePtr): XmlNodePtr;
     _xmlCleanupInputCallbacks(): void;
+    _xmlCreatePushParserCtxt(
+        sax: Pointer,
+        userData: Pointer,
+        chunk: CString,
+        size: number,
+        filename: CString,
+    ): XmlParserCtxtPtr;
+    _xmlCtxtGetDocument(ctxt: XmlParserCtxtPtr): XmlDocPtr;
     _xmlCtxtParseDtd(
         ctxt: XmlParserCtxtPtr,
         input: XmlParserInputPtr,
@@ -59,6 +67,7 @@ export class LibXml2 {
         handler: XmlStructuredErrorFunc,
         data: Pointer,
     ): void;
+    _xmlCtxtSetOptions(ctxt: XmlParserCtxtPtr, options: number): number;
     _xmlCtxtValidateDtd(ctxt: XmlParserCtxtPtr, doc: XmlDocPtr, dtd: XmlDtdPtr): number;
     _xmlFreeNode(node: XmlNodePtr): void;
     _xmlFreeParserCtxt(ctxt: XmlParserCtxtPtr): void;
@@ -87,6 +96,12 @@ export class LibXml2 {
     _xmlNewReference(doc: XmlDocPtr, name: CString): XmlNodePtr;
     _xmlNodeGetContent(node: XmlNodePtr): CString;
     _xmlNodeSetContentLen(node: XmlNodePtr, content: CString, len: number): number;
+    _xmlParseChunk(
+        ctxt: XmlParserCtxtPtr,
+        chunk: CString,
+        size: number,
+        terminate: number,
+    ): number;
     _xmlRegisterInputCallbacks(
         xmlInputMatchCallback: Pointer,
         xmlInputOpenCallback: Pointer,
@@ -126,6 +141,7 @@ export class LibXml2 {
     _xmlSearchNs(doc: XmlDocPtr, node: XmlNodePtr, prefix: CString): XmlNsPtr;
     _xmlSetNs(node: XmlNodePtr, ns: XmlNsPtr): void;
     _xmlSetNsProp(node: XmlNodePtr, ns: XmlNsPtr, name: CString, value: CString): XmlAttrPtr;
+    _xmlStopParser(ctxt: XmlParserCtxtPtr): void;
     _xmlXIncludeFreeContext(ctx: XmlXIncludeCtxtPtr): void;
     _xmlXIncludeNewContext(doc: XmlDocPtr): XmlXIncludeCtxtPtr;
     _xmlXIncludeProcessNode(ctxt: XmlXIncludeCtxtPtr, node: XmlNodePtr): number;

--- a/src/sax.mts
+++ b/src/sax.mts
@@ -171,6 +171,7 @@ export class XmlSaxParser extends XmlDisposable<XmlSaxParser> {
             );
         }
         const [ctxt, context] = xmlCreatePushParserCtxt(handler, options.url ?? null);
+        /* c8 ignore next 3, defensive: the context creation fails only when out of memory */
         if (!ctxt) {
             throw new XmlError('Failed to create the parser context');
         }
@@ -325,6 +326,7 @@ export class XmlSaxParser extends XmlDisposable<XmlSaxParser> {
 
     private get details(): ErrorDetail[] {
         const errIndex = errorIndices.get(this._ptr);
+        /* c8 ignore next, defensive: a live context always has its error storage */
         return errIndex === undefined ? [] : error.storage.get(errIndex);
     }
 
@@ -353,6 +355,7 @@ export class XmlSaxParser extends XmlDisposable<XmlSaxParser> {
             this._terminated = true;
             xmlStopParser(this._ptr);
             throw err;
+            /* c8 ignore next, unreachable: the catch always rethrows */
         } finally {
             this.parsing = false;
         }

--- a/src/sax.mts
+++ b/src/sax.mts
@@ -1,0 +1,364 @@
+import { disposeBy, XmlDisposable } from './disposable.mjs';
+import { buildParseError, ParseOption } from './document.mjs';
+import {
+    error,
+    XML_ERR_ERROR,
+    xmlCreatePushParserCtxt,
+    xmlCtxtSetErrorHandler,
+    xmlCtxtSetOptions,
+    XmlError,
+    xmlFreeSaxParserCtxt,
+    xmlParseChunk,
+    xmlStopParser,
+} from './libxml2.mjs';
+
+import type { ParseOptions } from './document.mjs';
+import type { ErrorDetail, SaxParserContext, XmlSaxHandler } from './libxml2.mjs';
+import type { XmlParserCtxtPtr } from './libxml2raw.mjs';
+
+// Per-context index of the collected ErrorDetail storage,
+// kept out of the instance so that it can be released
+// when the context is freed through garbage collection.
+const errorIndices = new Map<XmlParserCtxtPtr, number>();
+
+function freeSaxParser(ctxt: XmlParserCtxtPtr) {
+    // the context first: freeing it may still report a (defensive)
+    // diagnostic into the error storage
+    xmlFreeSaxParserCtxt(ctxt);
+    const errIndex = errorIndices.get(ctxt);
+    if (errIndex !== undefined) {
+        error.storage.free(errIndex);
+        errorIndices.delete(ctxt);
+    }
+}
+
+// %TypedArray%.prototype[@@toStringTag] is a getter reading the internal
+// [[TypedArrayName]] slot: unlike instanceof it identifies a genuine
+// Uint8Array from any realm (node:vm, a worker), and unlike
+// Object.prototype.toString it cannot be forged with a Symbol.toStringTag
+// property on a plain object.
+const typedArrayTag = Object.getOwnPropertyDescriptor(
+    Object.getPrototypeOf(Uint8Array.prototype),
+    Symbol.toStringTag,
+);
+
+function isUint8Array(chunk: unknown): chunk is Uint8Array {
+    return chunk instanceof Uint8Array
+        || typedArrayTag?.get?.call(chunk) === 'Uint8Array';
+}
+
+/**
+ * A streaming (push) XML parser.
+ *
+ * `XmlSaxParser` wraps libxml2's push parser with SAX2 callbacks:
+ * the document is fed incrementally, as raw bytes, with {@link push},
+ * and its content is reported through the {@link XmlSaxHandler} callbacks
+ * as soon as it has been parsed, without building an {@link XmlDocument}.
+ * Memory usage therefore does not grow proportionally with the document size.
+ *
+ * The input may be split into chunks at arbitrary byte positions.
+ * The encoding of the document is detected automatically,
+ * from its BOM or XML declaration;
+ * the callbacks always receive UTF-8 data.
+ *
+ * Entity references - predefined (`&amp;` …), character references
+ * (`&#xA9;` …) and entities declared in the internal DTD subset -
+ * are substituted in element content, and their replacement text is
+ * reported through the regular callbacks:
+ * {@link XmlSaxHandler#characters} for character data,
+ * and the element callbacks for any markup it contains.
+ * In attribute values, references to DTD-declared entities are passed
+ * through literally unless {@link ParseOption.XML_PARSE_NOENT} is set -
+ * see {@link XmlSaxAttribute#value}.
+ *
+ * Like other objects owning libxml2 memory, the parser must be released with
+ * {@link dispose}, or a `using` declaration.
+ *
+ * From within a handler callback, the only method that may be called on the
+ * parser is {@link stop}: the callback is invoked while libxml2 is parsing,
+ * so re-entering the parser with {@link push} or {@link finish}, or freeing
+ * it with {@link dispose}, throws an {@link XmlError}.
+ *
+ * @example
+ * ```js
+ * const decoder = new TextDecoder();
+ * let title = '';
+ * let inTitle = false;
+ * using parser = XmlSaxParser.create({
+ *     startElementNs(localName) { inTitle = localName === 'title'; },
+ *     endElementNs() { inTitle = false; },
+ *     characters(data) {
+ *         if (inTitle) title += decoder.decode(data, { stream: true });
+ *     },
+ * });
+ * for (const chunk of chunks) { // Uint8Array chunks, e.g. from a file stream
+ *     parser.push(chunk);
+ * }
+ * parser.finish();
+ * ```
+ *
+ * @see {@link XmlSaxHandler}
+ * @alpha
+ */
+@disposeBy(freeSaxParser)
+export class XmlSaxParser extends XmlDisposable<XmlSaxParser> {
+    /** No more input is accepted: finish() or stop() was called,
+     * or parsing failed. */
+    private _terminated = false;
+
+    /** Parsing was ended deliberately with stop(); implies terminated,
+     * and makes the error code of the aborted parse call ignorable. */
+    private _stopped = false;
+
+    /** libxml2 is inside xmlParseChunk, so its frames are live and a handler
+     * callback may be running; re-entering or freeing the parser now would
+     * leave libxml2 parsing corrupted or freed state. */
+    private parsing = false;
+
+    /** The callback dispatch context. libxml2.mts holds it weakly, so that a
+     * handler referring back to its own parser doesn't keep the parser alive;
+     * this reference owns it, for as long as the parser is reachable. */
+    private saxContext?: SaxParserContext;
+
+    /**
+     * Release the parser.
+     *
+     * @throws {@link XmlError} when called from within a handler callback,
+     * where freeing the context would leave libxml2 parsing on freed memory;
+     * dispose the parser after the {@link push} or {@link finish} call returns.
+     */
+    override [Symbol.dispose](): void {
+        if (this.parsing) {
+            throw new XmlError('The parser cannot be disposed from a handler callback');
+        }
+        super[Symbol.dispose]();
+    }
+
+    /**
+     * Create a push parser reporting to the given SAX handler.
+     *
+     * @param handler The callbacks receiving the parsing events
+     * @param options Parsing options;
+     * {@link ParseOptions#url} is used as the document URL in diagnostics and
+     * {@link ParseOptions#option} is applied to the parser context.
+     * Note: {@link ParseOption.XML_PARSE_HUGE} lifts libxml2's 10MB limit on a
+     * single construct that has to be buffered before it can be reported,
+     * such as a CDATA section.
+     * Plain character data is streamed incrementally and is not subject to
+     * this limit.
+     * The options documented as not supported by the push parser cannot be
+     * relied on: {@link ParseOption.XML_PARSE_NOBLANKS} has no effect, and
+     * {@link ParseOption.XML_PARSE_RECOVER} only lets the events of the chunk
+     * being pushed run to its end before the call throws all the same.
+     * @throws {@link XmlError} when a document encoding is passed - the push
+     * parser detects the encoding from the document itself - or when
+     * {@link ParseOption.XML_PARSE_DTDVALID} is requested: libxml2 validates
+     * against the tree that this parser deliberately doesn't build, so the
+     * option would silently accept invalid documents.
+     * @throws {@link XmlError} when {@link ParseOptions#option} contains bits
+     * that this build of libxml2 doesn't support, which it would otherwise
+     * silently ignore.
+     */
+    static create(handler: XmlSaxHandler, options: ParseOptions = {}): XmlSaxParser {
+        if (options.encoding && options.encoding !== 'utf-8') {
+            throw new XmlError(
+                'Setting an encoding is not supported, the parser detects it from the document',
+            );
+        }
+        if (options.option && (options.option & ParseOption.XML_PARSE_DTDVALID) !== 0) {
+            throw new XmlError(
+                'DTD validation is not supported, it needs the document tree',
+            );
+        }
+        const [ctxt, context] = xmlCreatePushParserCtxt(handler, options.url ?? null);
+        if (!ctxt) {
+            throw new XmlError('Failed to create the parser context');
+        }
+        try {
+            const optionBits = options.option ?? ParseOption.XML_PARSE_DEFAULT;
+            context.reportDtdDefaultedAttrs = (optionBits & ParseOption.XML_PARSE_DTDATTR) !== 0;
+            // xmlCtxtSetOptions returns the option bits it doesn't support.
+            // XML_PARSE_SKIP_IDS is reported unknown but nonetheless applied
+            // (through ctxt->loadsubset); the subtraction clears its bit
+            // before the check.
+            const rejected = xmlCtxtSetOptions(ctxt, optionBits);
+            const unsupported = rejected - (rejected & ParseOption.XML_PARSE_SKIP_IDS);
+            if (unsupported !== 0) {
+                throw new XmlError(`Unsupported parser options: 0x${unsupported.toString(16)}`);
+            }
+            const errIndex = error.storage.allocate([]);
+            errorIndices.set(ctxt, errIndex);
+            xmlCtxtSetErrorHandler(ctxt, error.errorCollector, errIndex);
+            const parser = XmlSaxParser.getInstance(ctxt);
+            parser.saxContext = context;
+            return parser;
+        } catch (err) {
+            freeSaxParser(ctxt);
+            throw err;
+        }
+    }
+
+    /**
+     * No more input is accepted: {@link finish} or {@link stop} was called,
+     * parsing failed, or the parser was disposed.
+     *
+     * Test it to leave a feeding loop that a callback ended with {@link stop}.
+     */
+    get terminated(): boolean {
+        return this._ptr === 0 || this._terminated;
+    }
+
+    /**
+     * Non-fatal diagnostics (warning-level, {@link ErrorDetail#level} === 1)
+     * emitted by libxml2 so far.
+     * Fatal diagnostics are thrown by {@link push} or {@link finish}
+     * as {@link XmlParseError}.
+     *
+     * @throws {@link XmlError} when the parser is disposed;
+     * the diagnostics are released with it, so read them before.
+     */
+    get warnings(): ErrorDetail[] {
+        if (this._ptr === 0) {
+            throw new XmlError('The parser is disposed');
+        }
+        return this.details.filter((d) => d.level < XML_ERR_ERROR);
+    }
+
+    /**
+     * Fatal diagnostics (error-level, {@link ErrorDetail#level} >= 2)
+     * emitted by libxml2 so far.
+     * {@link push} and {@link finish} already throw these as
+     * {@link XmlParseError}; this getter exists for a parser ended early
+     * with {@link stop}, which discards the ability to see them any other
+     * way since {@link finish} - the only method that checks for them - can
+     * no longer be called.
+     *
+     * @throws {@link XmlError} when the parser is disposed;
+     * the diagnostics are released with it, so read them before.
+     */
+    get errors(): ErrorDetail[] {
+        if (this._ptr === 0) {
+            throw new XmlError('The parser is disposed');
+        }
+        return this.details.filter((d) => d.level >= XML_ERR_ERROR);
+    }
+
+    /**
+     * Feed a chunk of the document to the parser.
+     *
+     * The handler callbacks are invoked, synchronously,
+     * for everything that can be parsed with the data available so far.
+     * Call {@link finish} after the last chunk.
+     *
+     * @param chunk The next raw bytes of the document, as a `Uint8Array`
+     * (a Node.js `Buffer` is one and is accepted as-is);
+     * a decoded string is not accepted, the parser needs the bytes to detect
+     * the encoding of the document
+     * @throws {@link XmlParseError} when the chunk is malformed;
+     * rethrows the exception if a handler callback throws one,
+     * in which case parsing is aborted.
+     * @throws {@link XmlError} when the chunk is not a `Uint8Array`.
+     */
+    push(chunk: Uint8Array): void {
+        if (!isUint8Array(chunk)) {
+            throw new XmlError('The chunk must be a Uint8Array of the raw document bytes');
+        }
+        this.ensureAcceptingInput();
+        const err = this.parseChunk(chunk, false);
+        if (err !== 0 && !this._stopped) {
+            this._terminated = true;
+            this.throwParseError();
+        }
+    }
+
+    /**
+     * Terminate parsing, processing any pending data.
+     *
+     * {@link XmlSaxHandler#endDocument} is invoked before this method returns,
+     * for a truncated or otherwise malformed document as well as for a
+     * complete one: it marks the end of the events, not a successful parse.
+     * Only this method returning without throwing does.
+     * The parser cannot be reused afterwards; it still has to be
+     * {@link dispose}d.
+     *
+     * @throws {@link XmlParseError} when the document is incomplete or
+     * otherwise malformed;
+     * rethrows the exception if a handler callback throws one.
+     */
+    finish(): void {
+        this.ensureAcceptingInput();
+        const err = this.parseChunk(null, true);
+        this._terminated = true;
+        // a stop() - issued by the endDocument callback of this very call -
+        // discards the error code of the call it aborted, but not
+        // error-level diagnostics collected before it: returning cleanly
+        // still has to mean the consumed input was well-formed
+        if ((err !== 0 && !this._stopped)
+            || this.details.some((d) => d.level >= XML_ERR_ERROR)) {
+            this.throwParseError();
+        }
+    }
+
+    /**
+     * Stop parsing before the end of the document, without raising an error.
+     *
+     * No further handler callback will be invoked.
+     * May be called from within a handler callback;
+     * the {@link push} call being processed then returns without error,
+     * and any parse error pending from that aborted call is discarded.
+     * Afterwards the parser accepts no more input and only needs to be
+     * {@link dispose}d.
+     * {@link finish} - the only method that raises {@link XmlParseError} for
+     * error-level diagnostics - can then no longer be called; inspect
+     * {@link errors} if the document may already have been malformed.
+     *
+     * Has no effect if parsing is already terminated.
+     */
+    stop(): void {
+        if (this._ptr === 0 || this._terminated) {
+            return;
+        }
+        xmlStopParser(this._ptr);
+        this._stopped = true;
+        this._terminated = true;
+    }
+
+    private get details(): ErrorDetail[] {
+        const errIndex = errorIndices.get(this._ptr);
+        return errIndex === undefined ? [] : error.storage.get(errIndex);
+    }
+
+    private ensureAcceptingInput(): void {
+        if (this._ptr === 0) {
+            throw new XmlError('The parser is disposed');
+        }
+        // before the terminated check: after stop() both hold, and being
+        // inside a callback is then the more useful diagnostic
+        if (this.parsing) {
+            throw new XmlError('The parser cannot be re-entered from a handler callback');
+        }
+        if (this._terminated) {
+            throw new XmlError('Parsing is already terminated');
+        }
+    }
+
+    private parseChunk(chunk: Uint8Array | null, terminate: boolean): number {
+        this.parsing = true;
+        try {
+            return xmlParseChunk(this._ptr, chunk, terminate);
+        } catch (err) {
+            // a handler callback threw (the trampoline already stopped the
+            // parser) or marshalling the chunk failed; make sure the native
+            // side accepts no more input either before handing the error on
+            this._terminated = true;
+            xmlStopParser(this._ptr);
+            throw err;
+        } finally {
+            this.parsing = false;
+        }
+    }
+
+    private throwParseError(): never {
+        throw buildParseError(this.details);
+    }
+}

--- a/test/backend/nodejs.spec.mts
+++ b/test/backend/nodejs.spec.mts
@@ -1,6 +1,7 @@
 import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import { join, resolve } from 'node:path';
+import vm from 'node:vm';
 
 import { expect, use } from 'chai';
 import sinon from 'sinon';
@@ -9,6 +10,7 @@ import sinonChai from 'sinon-chai';
 import {
     xmlCleanupInputProvider,
     XmlDocument,
+    XmlSaxParser,
     XmlValidateError,
     XsdValidator,
 } from '@libxml2-wasm/lib/index.mjs';
@@ -223,4 +225,21 @@ describe('Path handling', () => {
             expect(doc.get('/book/author/first-name')?.content).to.equal('Frank');
         });
     }
+});
+
+describe('XmlSaxParser cross-realm input', () => {
+    it('accepts a Uint8Array created in another realm', () => {
+        // instanceof fails across realms; push must not reject the chunk
+        const foreign: Uint8Array = vm.runInNewContext(
+            'new Uint8Array([60, 100, 111, 99, 47, 62])', // '<doc/>'
+        );
+        expect(foreign).to.not.be.an.instanceOf(Uint8Array);
+        const names: string[] = [];
+        using parser = XmlSaxParser.create({
+            startElementNs: (localName) => names.push(localName),
+        });
+        parser.push(foreign);
+        parser.finish();
+        expect(names).to.deep.equal(['doc']);
+    });
 });

--- a/test/backend/saxMemory.spec.mts
+++ b/test/backend/saxMemory.spec.mts
@@ -1,0 +1,69 @@
+import { expect } from 'chai';
+
+import { XmlParseError, XmlSaxParser } from '@libxml2-wasm/lib/index.mjs';
+
+const encoder = new TextEncoder();
+
+const ITERATIONS = 16;
+
+/**
+ * A document declaring a 4MB entity in its internal subset, cut short after the
+ * first element: even in SAX mode, libxml2 keeps the entities it parsed in a
+ * document of its own, and releases it only when the parse runs to its end.
+ */
+const prologue = encoder.encode(
+    `<!DOCTYPE d [<!ENTITY big "${'x'.repeat(4 * 1024 * 1024)}">]><d><a/>`,
+);
+
+function rss(): number {
+    (global as any).gc();
+    return process.memoryUsage().rss;
+}
+
+/**
+ * Memory still held after running `parse` `ITERATIONS` times.
+ * The first run is untimed and unmeasured: it grows the WebAssembly heap to the
+ * size this document needs, which would otherwise be charged to the caller.
+ */
+function retained(parse: () => void): number {
+    parse();
+    const before = rss();
+    for (let i = 0; i < ITERATIONS; i += 1) {
+        parse();
+    }
+    return rss() - before;
+}
+
+describe('XmlSaxParser memory', () => {
+    // without the release of the entity store in xmlFreeSaxParserCtxt, every
+    // iteration leaks its 4MB entity, i.e. >100MB over the loop
+    const budget = 32 * 1024 * 1024;
+
+    it('releases everything of a stopped parse', () => {
+        expect(retained(() => {
+            using parser = XmlSaxParser.create({
+                startElementNs: (localName) => {
+                    if (localName === 'a') {
+                        parser.stop();
+                    }
+                },
+            });
+            parser.push(prologue);
+        })).to.be.lessThan(budget);
+    }).timeout(20000);
+
+    it('releases everything of a failed parse', () => {
+        expect(retained(() => {
+            using parser = XmlSaxParser.create({});
+            parser.push(prologue);
+            expect(() => parser.push(encoder.encode('</wrong>'))).to.throw(XmlParseError);
+        })).to.be.lessThan(budget);
+    }).timeout(20000);
+
+    it('releases everything of a parse that is never finished', () => {
+        expect(retained(() => {
+            using parser = XmlSaxParser.create({});
+            parser.push(prologue);
+        })).to.be.lessThan(budget);
+    }).timeout(20000);
+});

--- a/test/backend/saxStreaming.spec.mts
+++ b/test/backend/saxStreaming.spec.mts
@@ -1,0 +1,212 @@
+import { expect } from 'chai';
+
+import { XmlSaxParser } from '@libxml2-wasm/lib/index.mjs';
+
+/**
+ * Consumer example: single-pass extraction from a large document.
+ *
+ * This spec doubles as documentation of the intended usage pattern of
+ * {@link XmlSaxParser}: a small, application-side extractor tracks its
+ * position with startElementNs/endElementNs, decodes only the character
+ * data it is interested in, and skips a giant embedded text node by
+ * looking at `data.length` alone - keeping peak memory flat regardless
+ * of the document size. Nothing in this file ships with the library.
+ */
+
+interface InvoiceLine {
+    id: string;
+    quantity: string;
+    item: string;
+    amount: string;
+    currency: string;
+}
+
+/** Application-side extractor built on the SAX events. */
+class InvoiceExtractor {
+    id = '';
+
+    issueDate = '';
+
+    attachmentMimeCode = '';
+
+    /** size of the (skipped) attachment content, in bytes */
+    attachmentLength = 0;
+
+    lines: InvoiceLine[] = [];
+
+    /** element names from the document root down to the current element */
+    private readonly path: string[] = [];
+
+    /** depth of the <Invoice> element, once found at any depth */
+    private invoiceDepth = 0;
+
+    private line: InvoiceLine | null = null;
+
+    private captured: Uint8Array[] | null = null;
+
+    readonly handler = {
+        startElementNs: (
+            localName: string,
+            prefix: string | null,
+            namespaceUri: string | null,
+            namespaces: [prefix: string | null, uri: string][],
+            attributes: { localName: string; value: string }[],
+        ): void => {
+            this.path.push(localName);
+            if (this.invoiceDepth === 0) {
+                // the interesting document may be nested in an envelope at any depth
+                if (localName === 'Invoice' && namespaceUri === 'urn:invoice') {
+                    this.invoiceDepth = this.path.length;
+                }
+                return;
+            }
+            switch (this.relativePath()) {
+                case 'ID':
+                case 'IssueDate':
+                case 'Lines/Line/Item':
+                case 'Lines/Line/Amount':
+                    this.captured = [];
+                    break;
+                case 'Attachment':
+                    this.attachmentMimeCode = attributes
+                        .find((a) => a.localName === 'mimeCode')?.value ?? '';
+                    break;
+                case 'Lines/Line':
+                    this.line = {
+                        id: attributes.find((a) => a.localName === 'id')?.value ?? '',
+                        quantity: attributes.find((a) => a.localName === 'quantity')?.value ?? '',
+                        item: '',
+                        amount: '',
+                        currency: '',
+                    };
+                    break;
+                default:
+            }
+            if (this.relativePath() === 'Lines/Line/Amount') {
+                this.line!.currency = attributes
+                    .find((a) => a.localName === 'currency')?.value ?? '';
+            }
+        },
+
+        endElementNs: (): void => {
+            const relative = this.relativePath();
+            if (this.captured) {
+                const text = decodeConcatenated(this.captured);
+                this.captured = null;
+                switch (relative) {
+                    case 'ID':
+                        this.id = text;
+                        break;
+                    case 'IssueDate':
+                        this.issueDate = text;
+                        break;
+                    case 'Lines/Line/Item':
+                        this.line!.item = text;
+                        break;
+                    case 'Lines/Line/Amount':
+                        this.line!.amount = text;
+                        break;
+                    /* c8 ignore next */
+                    default:
+                }
+            }
+            if (relative === 'Lines/Line' && this.line) {
+                this.lines.push(this.line);
+                this.line = null;
+            }
+            this.path.pop();
+        },
+
+        characters: (data: Uint8Array): void => {
+            if (this.captured) {
+                // interesting text: copy it out of the wasm memory
+                this.captured.push(data.slice());
+            } else if (this.relativePath() === 'Attachment') {
+                // the giant base64 node: skipping costs one length read
+                this.attachmentLength += data.length;
+            }
+        },
+    };
+
+    private relativePath(): string {
+        return this.path.slice(this.invoiceDepth).join('/');
+    }
+}
+
+function decodeConcatenated(chunks: Uint8Array[]): string {
+    // character data may be split at arbitrary byte positions:
+    // decode the concatenation, not the individual chunks
+    const decoder = new TextDecoder();
+    return chunks.reduce(
+        (text, chunk, i) => text + decoder.decode(chunk, { stream: i < chunks.length - 1 }),
+        '',
+    );
+}
+
+const LINE_COUNT = 2000;
+const ATTACHMENT_LENGTH = 20 * 1024 * 1024;
+
+/** Build a ~20MB document: a few small fields, a repeated group and
+ * one giant base64 text node, wrapped in an envelope. */
+function generateDocument(): Uint8Array {
+    const encoder = new TextEncoder();
+    const head = encoder.encode(`<?xml version="1.0" encoding="UTF-8"?>
+<env:Envelope xmlns:env="urn:envelope"><env:Body><Invoice xmlns="urn:invoice">
+<ID>INV-2026-00042</ID><IssueDate>2026-08-08</IssueDate>
+<Attachment mimeCode="application/pdf">`);
+    const attachment = new Uint8Array(ATTACHMENT_LENGTH).fill(0x41); // base64-like 'A's
+    const lines: string[] = ['</Attachment>\n<Lines>'];
+    for (let i = 1; i <= LINE_COUNT; i += 1) {
+        lines.push(`<Line id="L${i}" quantity="${i % 10}">`
+            + `<Item>Widget ${i}</Item>`
+            + `<Amount currency="EUR">${i}.00</Amount></Line>`);
+    }
+    lines.push('</Lines></Invoice></env:Body></env:Envelope>');
+    const tail = encoder.encode(lines.join('\n'));
+    const doc = new Uint8Array(head.length + attachment.length + tail.length);
+    doc.set(head);
+    doc.set(attachment, head.length);
+    doc.set(tail, head.length + attachment.length);
+    return doc;
+}
+
+describe('XmlSaxParser streaming extraction (consumer example)', () => {
+    it('extracts fields and repeated groups from a ~20MB document with flat memory', () => {
+        const document = generateDocument();
+        expect(document.length).to.be.greaterThan(20 * 1024 * 1024);
+
+        (global as any).gc();
+        const rssBefore = process.memoryUsage().rss;
+
+        const extractor = new InvoiceExtractor();
+        using parser = XmlSaxParser.create(extractor.handler);
+        // arbitrary chunking, as delivered by a network or file stream
+        const chunkSize = 65521;
+        for (let offset = 0; offset < document.length; offset += chunkSize) {
+            parser.push(document.subarray(offset, offset + chunkSize));
+        }
+        parser.finish();
+
+        const rssAfter = process.memoryUsage().rss;
+
+        expect(extractor.id).to.equal('INV-2026-00042');
+        expect(extractor.issueDate).to.equal('2026-08-08');
+        expect(extractor.attachmentMimeCode).to.equal('application/pdf');
+        expect(extractor.attachmentLength).to.equal(ATTACHMENT_LENGTH);
+        expect(extractor.lines).to.have.lengthOf(LINE_COUNT);
+        expect(extractor.lines[0]).to.deep.equal({
+            id: 'L1', quantity: '1', item: 'Widget 1', amount: '1.00', currency: 'EUR',
+        });
+        expect(extractor.lines[LINE_COUNT - 1]).to.deep.equal({
+            id: `L${LINE_COUNT}`,
+            quantity: `${LINE_COUNT % 10}`,
+            item: `Widget ${LINE_COUNT}`,
+            amount: `${LINE_COUNT}.00`,
+            currency: 'EUR',
+        });
+
+        // peak memory stays far below the document size:
+        // the giant text node is skipped without being copied or decoded
+        expect(rssAfter - rssBefore).to.be.lessThan(16 * 1024 * 1024);
+    });
+});

--- a/test/crossplatform/sax.spec.mts
+++ b/test/crossplatform/sax.spec.mts
@@ -1,0 +1,887 @@
+import { expect } from 'chai';
+
+import {
+    diag,
+    ParseOption,
+    XmlError,
+    XmlParseError,
+    XmlSaxParser,
+} from '@libxml2-wasm/lib/index.mjs';
+
+import type { XmlSaxHandler } from '@libxml2-wasm/lib/index.mjs';
+
+const encoder = new TextEncoder();
+
+type SaxEvent = [name: string, ...args: unknown[]];
+
+function recordingHandler(events: SaxEvent[]): XmlSaxHandler {
+    const decoder = new TextDecoder();
+    return {
+        startDocument: () => events.push(['startDocument']),
+        endDocument: () => events.push(['endDocument']),
+        startElementNs: (localName, prefix, namespaceUri, namespaces, attributes) => events
+            .push(['startElementNs', localName, prefix, namespaceUri, namespaces, attributes]),
+        endElementNs: (localName, prefix, namespaceUri) => events
+            .push(['endElementNs', localName, prefix, namespaceUri]),
+        characters: (data) => events.push(['characters', decoder.decode(data)]),
+        cdataBlock: (data) => events.push(['cdataBlock', decoder.decode(data)]),
+        comment: (text) => events.push(['comment', text]),
+        processingInstruction: (target, data) => events
+            .push(['processingInstruction', target, data]),
+    };
+}
+
+function parse(
+    xml: string | Uint8Array,
+    handler: XmlSaxHandler,
+    option?: ParseOption,
+    chunkSize?: number,
+): void {
+    const bytes = typeof xml === 'string' ? encoder.encode(xml) : xml;
+    const size = chunkSize ?? bytes.length;
+    using parser = XmlSaxParser.create(handler, option === undefined ? {} : { option });
+    for (let offset = 0; offset < bytes.length; offset += size) {
+        parser.push(bytes.subarray(offset, offset + size));
+    }
+    parser.finish();
+}
+
+describe('XmlSaxParser', () => {
+    describe('create', () => {
+        it('rejects an explicit document encoding', () => {
+            expect(() => XmlSaxParser.create({}, { encoding: 'latin1' })).to.throw(
+                XmlError,
+                'Setting an encoding is not supported',
+            );
+        });
+
+        it('accepts the utf-8 encoding', () => {
+            using parser = XmlSaxParser.create({}, { encoding: 'utf-8' });
+            parser.push(encoder.encode('<doc/>'));
+            parser.finish();
+        });
+
+        it('rejects DTD validation', () => {
+            // libxml2 validates against the tree, which this parser doesn't
+            // build, so the option would silently accept invalid documents
+            expect(() => XmlSaxParser.create({}, {
+                option: ParseOption.XML_PARSE_DTDVALID,
+            })).to.throw(XmlError, 'DTD validation is not supported');
+        });
+
+        it('accepts DTD driven default attributes', () => {
+            const attributes: unknown[] = [];
+            parse(
+                '<!DOCTYPE d [<!ELEMENT d EMPTY><!ATTLIST d a CDATA "dflt">]><d/>',
+                {
+                    startElementNs: (localName, prefix, namespaceUri, namespaces, attrs) => {
+                        attributes.push(...attrs);
+                    },
+                },
+                ParseOption.XML_PARSE_DTDATTR,
+            );
+            expect(attributes).to.deep.equal([{
+                localName: 'a', prefix: null, namespaceUri: null, value: 'dflt',
+            }]);
+        });
+
+        it('omits DTD driven default attributes without XML_PARSE_DTDATTR', () => {
+            const attributes: unknown[] = [];
+            parse(
+                '<!DOCTYPE d [<!ELEMENT d EMPTY><!ATTLIST d a CDATA "dflt">]><d b="x"/>',
+                {
+                    startElementNs: (localName, prefix, namespaceUri, namespaces, attrs) => {
+                        attributes.push(...attrs);
+                    },
+                },
+            );
+            expect(attributes).to.deep.equal([{
+                localName: 'b', prefix: null, namespaceUri: null, value: 'x',
+            }]);
+        });
+
+        it('rejects options this build of libxml2 does not support', () => {
+            // SAX1 support is compiled out; without the check libxml2 would
+            // silently ignore the option
+            expect(() => XmlSaxParser.create({}, {
+                option: ParseOption.XML_PARSE_SAX1,
+            })).to.throw(XmlError, 'Unsupported parser options');
+        });
+
+        it('accepts XML_PARSE_SKIP_IDS although libxml2 reports it unknown', () => {
+            using parser = XmlSaxParser.create({}, {
+                option: ParseOption.XML_PARSE_SKIP_IDS,
+            });
+            parser.push(encoder.encode('<doc/>'));
+            parser.finish();
+        });
+    });
+
+    describe('push', () => {
+        it('rejects anything but a Uint8Array', () => {
+            using parser = XmlSaxParser.create({});
+            ['<doc/>', null, undefined, [0x3C], new ArrayBuffer(2)].forEach((bad) => {
+                expect(() => parser.push(bad as unknown as Uint8Array)).to.throw(
+                    XmlError,
+                    'The chunk must be a Uint8Array of the raw document bytes',
+                );
+            });
+        });
+
+        it('rejects a plain object forging the Uint8Array string tag', () => {
+            // Object.prototype.toString would report it as a Uint8Array,
+            // but its content would be coerced garbage in the wasm memory
+            using parser = XmlSaxParser.create({});
+            const forged = { [Symbol.toStringTag]: 'Uint8Array', length: 1, 0: 0x3C };
+            expect(() => parser.push(forged as unknown as Uint8Array)).to.throw(
+                XmlError,
+                'The chunk must be a Uint8Array of the raw document bytes',
+            );
+        });
+    });
+
+    describe('events', () => {
+        it('reports document, element, text, comment and PI events in order', () => {
+            const events: SaxEvent[] = [];
+            parse(
+                '<?xml version="1.0"?><!--note--><doc a="1"><child>text</child><?pi data?></doc>',
+                recordingHandler(events),
+            );
+            expect(events).to.deep.equal([
+                ['startDocument'],
+                ['comment', 'note'],
+                ['startElementNs', 'doc', null, null, [], [
+                    {
+                        localName: 'a', prefix: null, namespaceUri: null, value: '1',
+                    },
+                ]],
+                ['startElementNs', 'child', null, null, [], []],
+                ['characters', 'text'],
+                ['endElementNs', 'child', null, null],
+                ['processingInstruction', 'pi', 'data'],
+                ['endElementNs', 'doc', null, null],
+                ['endDocument'],
+            ]);
+        });
+
+        it('reports CDATA sections through cdataBlock', () => {
+            const events: SaxEvent[] = [];
+            parse('<doc><![CDATA[raw <>&]]></doc>', recordingHandler(events));
+            expect(events).to.deep.include(['cdataBlock', 'raw <>&']);
+        });
+
+        it('reports CDATA sections through characters when cdataBlock is not set', () => {
+            let text = '';
+            const decoder = new TextDecoder();
+            parse('<doc><![CDATA[raw <>&]]></doc>', {
+                characters: (data) => {
+                    text += decoder.decode(data, { stream: true });
+                },
+            });
+            expect(text).to.equal('raw <>&');
+        });
+
+        it('stops reporting startElementNs when it is removed mid-parse', () => {
+            const names: string[] = [];
+            const handler: XmlSaxHandler = {
+                startElementNs: (localName) => {
+                    names.push(localName);
+                    delete handler.startElementNs;
+                },
+            };
+            using parser = XmlSaxParser.create(handler);
+            parser.push(encoder.encode('<doc><a/><b/></doc>'));
+            parser.finish();
+            expect(names).to.deep.equal(['doc']);
+        });
+
+        it('parses documents with a handler without callbacks', () => {
+            parse('<doc><child>text</child><!--c--></doc>', {});
+        });
+    });
+
+    describe('namespaces', () => {
+        it('reports namespace declarations and resolved names', () => {
+            const events: SaxEvent[] = [];
+            parse(
+                '<doc xmlns="urn:default" xmlns:p="urn:p" p:a="1"><p:child b="2"/></doc>',
+                recordingHandler(events),
+            );
+            expect(events).to.deep.equal([
+                ['startDocument'],
+                ['startElementNs', 'doc', null, 'urn:default', [
+                    [null, 'urn:default'],
+                    ['p', 'urn:p'],
+                ], [
+                    {
+                        localName: 'a', prefix: 'p', namespaceUri: 'urn:p', value: '1',
+                    },
+                ]],
+                ['startElementNs', 'child', 'p', 'urn:p', [], [
+                    {
+                        localName: 'b', prefix: null, namespaceUri: null, value: '2',
+                    },
+                ]],
+                ['endElementNs', 'child', 'p', 'urn:p'],
+                ['endElementNs', 'doc', null, 'urn:default'],
+                ['endDocument'],
+            ]);
+        });
+    });
+
+    describe('attributes', () => {
+        function attributesOf(xml: string, option?: ParseOption) {
+            const attributes: unknown[] = [];
+            parse(xml, {
+                startElementNs: (localName, prefix, namespaceUri, namespaces, attrs) => attributes
+                    .push(...attrs),
+            }, option);
+            return attributes;
+        }
+
+        it('substitutes entities and character references in values', () => {
+            expect(attributesOf('<doc a="A &lt;&gt; &#65;"/>')).to.deep.equal([{
+                localName: 'a', prefix: null, namespaceUri: null, value: 'A <> A',
+            }]);
+        });
+
+        it('reports ampersands as &#38; without XML_PARSE_NOENT', () => {
+            // libxml2's SAX interface reports the ampersand unexpanded,
+            // as a character reference, to prevent double expansion
+            expect(attributesOf('<doc a="x&amp;y&#38;z"/>')).to.deep.equal([{
+                localName: 'a', prefix: null, namespaceUri: null, value: 'x&#38;y&#38;z',
+            }]);
+        });
+
+        it('reports plain ampersands with XML_PARSE_NOENT', () => {
+            expect(attributesOf(
+                '<doc a="x&amp;y&#38;z"/>',
+                ParseOption.XML_PARSE_NOENT,
+            )).to.deep.equal([{
+                localName: 'a', prefix: null, namespaceUri: null, value: 'x&y&z',
+            }]);
+        });
+
+        it('reports empty values', () => {
+            expect(attributesOf('<doc a=""/>')).to.deep.equal([{
+                localName: 'a', prefix: null, namespaceUri: null, value: '',
+            }]);
+        });
+
+        it('passes DTD-declared entity references through without XML_PARSE_NOENT', () => {
+            expect(attributesOf('<!DOCTYPE doc [<!ENTITY e "xyz">]><doc a="q&e;r"/>'))
+                .to.deep.equal([{
+                    localName: 'a', prefix: null, namespaceUri: null, value: 'q&e;r',
+                }]);
+        });
+
+        it('substitutes DTD-declared entities with XML_PARSE_NOENT', () => {
+            expect(attributesOf(
+                '<!DOCTYPE doc [<!ENTITY e "xyz">]><doc a="q&e;r"/>',
+                ParseOption.XML_PARSE_NOENT,
+            )).to.deep.equal([{
+                localName: 'a', prefix: null, namespaceUri: null, value: 'qxyzr',
+            }]);
+        });
+    });
+
+    describe('chunked input', () => {
+        it('parses one-byte pushes, split inside tags, entities and UTF-8 sequences', () => {
+            const events: SaxEvent[] = [];
+            let bytes = new Uint8Array(0);
+            parse('<doc łđ="češće">A&amp;š&#x1F600;<!--čob--></doc>', {
+                ...recordingHandler(events),
+                // splits between characters callbacks are not guaranteed to
+                // fall on UTF-8 character boundaries: collect raw bytes and
+                // decode once at the end
+                characters: (data) => {
+                    const grown = new Uint8Array(bytes.length + data.length);
+                    grown.set(bytes);
+                    grown.set(data, bytes.length);
+                    bytes = grown;
+                },
+            }, undefined, 1);
+            const text = new TextDecoder().decode(bytes);
+            expect(text).to.equal('A&š😀');
+            expect(events).to.deep.equal([
+                ['startDocument'],
+                ['startElementNs', 'doc', null, null, [], [
+                    {
+                        localName: 'łđ', prefix: null, namespaceUri: null, value: 'češće',
+                    },
+                ]],
+                ['comment', 'čob'],
+                ['endElementNs', 'doc', null, null],
+                ['endDocument'],
+            ]);
+        });
+
+        it('decodes character data with a streaming TextDecoder', () => {
+            const decoder = new TextDecoder();
+            let text = '';
+            parse('<doc>šđčćž €😀</doc>', {
+                characters: (data) => {
+                    text += decoder.decode(data, { stream: true });
+                },
+            }, undefined, 1);
+            expect(text).to.equal('šđčćž €😀');
+        });
+
+        it('detects the encoding of UTF-16 input from its BOM', () => {
+            const body = '<doc č="ž">tešt</doc>';
+            const bytes = new Uint8Array(2 + body.length * 2);
+            bytes[0] = 0xFF; // UTF-16LE BOM
+            bytes[1] = 0xFE;
+            for (let i = 0; i < body.length; i += 1) {
+                const code = body.charCodeAt(i);
+                bytes[2 + 2 * i] = code % 256;
+                bytes[3 + 2 * i] = Math.floor(code / 256);
+            }
+            const decoder = new TextDecoder();
+            const names: string[] = [];
+            let attributes: unknown[] = [];
+            let text = '';
+            parse(bytes, {
+                startElementNs: (localName, prefix, namespaceUri, namespaces, attrs) => {
+                    names.push(localName);
+                    attributes = attrs;
+                },
+                characters: (data) => {
+                    text += decoder.decode(data, { stream: true });
+                },
+            }, undefined, 3);
+            // the callbacks receive UTF-8 regardless of the input encoding
+            expect(names).to.deep.equal(['doc']);
+            expect(attributes).to.deep.equal([{
+                localName: 'č', prefix: null, namespaceUri: null, value: 'ž',
+            }]);
+            expect(text).to.equal('tešt');
+        });
+    });
+
+    describe('entities', () => {
+        function textOf(xml: string, option?: ParseOption, chunkSize?: number): string {
+            const decoder = new TextDecoder();
+            let text = '';
+            parse(xml, {
+                characters: (data) => {
+                    text += decoder.decode(data, { stream: true });
+                },
+            }, option, chunkSize);
+            return text;
+        }
+
+        it('substitutes predefined entities and character references', () => {
+            expect(textOf('<doc>a&amp;b&lt;c&gt;d&#64;e&#x40;f</doc>')).to.equal('a&b<c>d@e@f');
+        });
+
+        it('substitutes entities declared in the internal DTD subset', () => {
+            expect(textOf('<!DOCTYPE doc [<!ENTITY e "xyz">]><doc>a&e;b</doc>'))
+                .to.equal('axyzb');
+        });
+
+        it('substitutes entities split across pushes', () => {
+            expect(textOf('<doc>a&amp;b</doc>', undefined, 1)).to.equal('a&b');
+        });
+
+        it('reports markup in entity replacement text as element events', () => {
+            const events: SaxEvent[] = [];
+            parse(
+                '<!DOCTYPE doc [<!ENTITY m "<b>t</b>">]><doc>&m;</doc>',
+                recordingHandler(events),
+            );
+            expect(events).to.deep.equal([
+                ['startDocument'],
+                ['startElementNs', 'doc', null, null, [], []],
+                ['startElementNs', 'b', null, null, [], []],
+                ['characters', 't'],
+                ['endElementNs', 'b', null, null],
+                ['endElementNs', 'doc', null, null],
+                ['endDocument'],
+            ]);
+        });
+    });
+
+    describe('large content', () => {
+        // libxml2 limits constructs it has to buffer to 10MB (XML_MAX_TEXT_LENGTH,
+        // XML_MAX_LOOKUP_LIMIT) unless XML_PARSE_HUGE is set
+        const bigLength = 11 * 1024 * 1024;
+        const chunk = new Uint8Array(256 * 1024).fill(0x61); // "a"
+
+        function pushBig(parser: XmlSaxParser, prologue: string, epilogue: string): void {
+            parser.push(encoder.encode(prologue));
+            for (let pushed = 0; pushed < bigLength; pushed += chunk.length) {
+                parser.push(chunk);
+            }
+            parser.push(encoder.encode(epilogue));
+            parser.finish();
+        }
+
+        it('streams a text node larger than 10MB without XML_PARSE_HUGE', () => {
+            let length = 0;
+            using parser = XmlSaxParser.create({
+                characters: (data) => {
+                    length += data.length;
+                },
+            });
+            pushBig(parser, '<doc>', '</doc>');
+            expect(length).to.equal(bigLength);
+        });
+
+        it('rejects a CDATA section larger than 10MB without XML_PARSE_HUGE', () => {
+            using parser = XmlSaxParser.create({});
+            expect(() => pushBig(parser, '<doc><![CDATA[', ']]></doc>')).to.throw(
+                XmlParseError,
+                /CData section too big|Buffer size limit exceeded/,
+            );
+        });
+
+        it('accepts a CDATA section larger than 10MB with XML_PARSE_HUGE', () => {
+            let length = 0;
+            using parser = XmlSaxParser.create(
+                {
+                    cdataBlock: (data) => {
+                        length += data.length;
+                    },
+                },
+                { option: ParseOption.XML_PARSE_HUGE },
+            );
+            pushBig(parser, '<doc><![CDATA[', ']]></doc>');
+            expect(length).to.equal(bigLength);
+        });
+    });
+
+    describe('errors', () => {
+        it('throws XmlParseError with detail from finish on premature end', () => {
+            using parser = XmlSaxParser.create({});
+            parser.push(encoder.encode('<doc>'));
+            expect(() => parser.finish()).to.throw(
+                XmlParseError,
+                'Premature end of data in tag doc line 1\n',
+            ).with.deep.property('details', [{
+                message: 'Premature end of data in tag doc line 1\n',
+                level: 3,
+                line: 1,
+                col: 6,
+            }]);
+        });
+
+        it('throws XmlParseError from push on a malformed chunk', () => {
+            using parser = XmlSaxParser.create({});
+            parser.push(encoder.encode('<doc>'));
+            expect(() => parser.push(encoder.encode('</wrong>'))).to.throw(
+                XmlParseError,
+                'Opening and ending tag mismatch: doc line 1 and wrong\n',
+            ).with.nested.property('details[0].level', 3);
+            // parsing cannot continue afterwards
+            expect(() => parser.push(encoder.encode('x'))).to.throw(
+                XmlError,
+                'Parsing is already terminated',
+            );
+        });
+
+        it('throws XmlParseError on an empty document', () => {
+            using parser = XmlSaxParser.create({});
+            expect(() => parser.finish()).to.throw(XmlParseError, 'Document is empty\n');
+        });
+
+        it('fails the parse on error-level diagnostics at finish', () => {
+            // an undeclared namespace prefix is a non-fatal (level 2) error:
+            // events are still delivered, and finish() fails like DOM parsing does
+            const names: string[] = [];
+            using parser = XmlSaxParser.create({
+                startElementNs: (localName) => {
+                    names.push(localName);
+                },
+            });
+            parser.push(encoder.encode('<doc><p:child/></doc>'));
+            expect(() => parser.finish()).to.throw(
+                XmlParseError,
+                'Namespace prefix p on child is not defined\n',
+            ).with.nested.property('details[0].level', 2);
+            expect(names).to.deep.equal(['doc', 'child']);
+        });
+
+        it('collects warning-level diagnostics without failing', () => {
+            using parser = XmlSaxParser.create({});
+            parser.push(encoder.encode('<doc xmlns="relative"/>'));
+            parser.finish();
+            expect(parser.warnings).to.deep.equal([{
+                message: 'xmlns: URI relative is not absolute\n',
+                level: 1,
+                line: 1,
+                col: 22,
+            }]);
+        });
+
+        it('attributes diagnostics to the document url', () => {
+            using parser = XmlSaxParser.create({}, { url: 'invoice.xml' });
+            parser.push(encoder.encode('<doc>'));
+            expect(() => parser.finish()).to.throw(XmlParseError)
+                .with.nested.property('details[0].file', 'invoice.xml');
+        });
+    });
+
+    describe('finish', () => {
+        it('rejects further input after finish', () => {
+            using parser = XmlSaxParser.create({});
+            parser.push(encoder.encode('<doc/>'));
+            parser.finish();
+            expect(() => parser.push(encoder.encode('<doc/>'))).to.throw(
+                XmlError,
+                'Parsing is already terminated',
+            );
+            expect(() => parser.finish()).to.throw(XmlError, 'Parsing is already terminated');
+        });
+    });
+
+    describe('stop', () => {
+        it('stops before any input has been pushed', () => {
+            using parser = XmlSaxParser.create({});
+            parser.stop();
+            expect(() => parser.push(encoder.encode('<doc/>'))).to.throw(
+                XmlError,
+                'Parsing is already terminated',
+            );
+        });
+
+        it('stops the parse from within a callback without error', () => {
+            const names: string[] = [];
+            using parser = XmlSaxParser.create({
+                startElementNs: (localName) => {
+                    names.push(localName);
+                    if (names.length === 2) {
+                        parser.stop();
+                    }
+                },
+            });
+            parser.push(encoder.encode('<doc><a/><b/><c/></doc>'));
+            expect(names).to.deep.equal(['doc', 'a']);
+        });
+
+        it('rejects further input after stop', () => {
+            using parser = XmlSaxParser.create({});
+            parser.push(encoder.encode('<doc>'));
+            expect(parser.terminated).to.be.false;
+            parser.stop();
+            expect(parser.terminated).to.be.true;
+            expect(() => parser.push(encoder.encode('</doc>'))).to.throw(
+                XmlError,
+                'Parsing is already terminated',
+            );
+            expect(() => parser.finish()).to.throw(XmlError, 'Parsing is already terminated');
+        });
+
+        it('lets a feeding loop end on the terminated flag', () => {
+            const names: string[] = [];
+            using parser = XmlSaxParser.create({
+                startElementNs: (localName) => {
+                    names.push(localName);
+                    if (localName === 'b') {
+                        parser.stop();
+                    }
+                },
+            });
+            const chunks = ['<doc>', '<a/>', '<b/>', '<c/>', '</doc>'];
+            for (let i = 0; i < chunks.length && !parser.terminated; i += 1) {
+                parser.push(encoder.encode(chunks[i]));
+            }
+            if (!parser.terminated) {
+                parser.finish();
+            }
+            expect(names).to.deep.equal(['doc', 'a', 'b']);
+        });
+
+        it('has no effect on a terminated or disposed parser', () => {
+            const parser = XmlSaxParser.create({});
+            parser.push(encoder.encode('<doc/>'));
+            parser.finish();
+            parser.stop();
+            parser.dispose();
+            parser.stop();
+        });
+
+        it('lets finish return cleanly when stopped from endDocument', () => {
+            using parser = XmlSaxParser.create({
+                endDocument: () => parser.stop(),
+            });
+            parser.push(encoder.encode('<doc/>'));
+            parser.finish();
+        });
+
+        it('does not mask earlier error-level diagnostics from finish', () => {
+            // stop() discards the error code of the call it aborts, but a
+            // clean finish() return still has to mean well-formed input
+            using parser = XmlSaxParser.create({
+                endDocument: () => parser.stop(),
+            });
+            parser.push(encoder.encode('<doc><p:child/></doc>'));
+            expect(() => parser.finish()).to.throw(
+                XmlParseError,
+                'Namespace prefix p on child is not defined\n',
+            );
+        });
+
+        it('exposes error-level diagnostics through errors once stopped', () => {
+            // finish() can no longer be called after stop(), so it is the
+            // only way left to see a diagnostic collected before stopping
+            using parser = XmlSaxParser.create({
+                startElementNs: (localName) => {
+                    if (localName === 'child') {
+                        parser.stop();
+                    }
+                },
+            });
+            parser.push(encoder.encode('<doc><p:child/></doc>'));
+            expect(parser.warnings).to.deep.equal([]);
+            expect(parser.errors).to.have.lengthOf(1);
+            expect(parser.errors[0].message)
+                .to.equal('Namespace prefix p on child is not defined\n');
+        });
+    });
+
+    describe('dispose', () => {
+        it('reports a disposed parser as terminated', () => {
+            const parser = XmlSaxParser.create({});
+            parser.push(encoder.encode('<doc>'));
+            expect(parser.terminated).to.be.false;
+            parser.dispose();
+            // a feeding loop leaving on `terminated` must not push again
+            expect(parser.terminated).to.be.true;
+        });
+    });
+
+    describe('re-entrancy', () => {
+        it('rejects push from within a callback', () => {
+            const parser = XmlSaxParser.create({
+                startElementNs: () => parser.push(encoder.encode('<nested/>')),
+            });
+            expect(() => parser.push(encoder.encode('<doc><child/></doc>'))).to.throw(
+                XmlError,
+                'The parser cannot be re-entered from a handler callback',
+            );
+            parser.dispose();
+        });
+
+        it('rejects finish from within a callback', () => {
+            const parser = XmlSaxParser.create({
+                endDocument: () => parser.finish(),
+            });
+            parser.push(encoder.encode('<doc/>'));
+            expect(() => parser.finish()).to.throw(
+                XmlError,
+                'The parser cannot be re-entered from a handler callback',
+            );
+            parser.dispose();
+        });
+
+        it('rejects dispose from within a callback', () => {
+            // freeing the context here would leave libxml2 parsing on freed memory
+            const parser = XmlSaxParser.create({
+                characters: () => parser.dispose(),
+            });
+            expect(() => parser.push(encoder.encode('<doc>text</doc>'))).to.throw(
+                XmlError,
+                'The parser cannot be disposed from a handler callback',
+            );
+            // the parser survived and can be released now that parsing is over
+            parser.dispose();
+            expect(() => parser.push(encoder.encode('x'))).to.throw(
+                XmlError,
+                'The parser is disposed',
+            );
+        });
+
+        it('reports being inside a callback rather than being stopped', () => {
+            // both conditions hold here; the re-entrancy is the useful diagnostic
+            using parser = XmlSaxParser.create({
+                startElementNs: () => {
+                    parser.stop();
+                    expect(() => parser.push(encoder.encode('x'))).to.throw(
+                        XmlError,
+                        'The parser cannot be re-entered from a handler callback',
+                    );
+                },
+            });
+            parser.push(encoder.encode('<doc/>'));
+        });
+
+        it('allows driving another parser from within a callback', () => {
+            // the guard is per parser, not global
+            const inner: SaxEvent[] = [];
+            using nested = XmlSaxParser.create(recordingHandler(inner));
+            const outer: SaxEvent[] = [];
+            const handler = recordingHandler(outer);
+            using parser = XmlSaxParser.create({
+                ...handler,
+                startElementNs: (...args) => {
+                    handler.startElementNs!(...args);
+                    nested.push(encoder.encode('<nested/>'));
+                },
+            });
+            parser.push(encoder.encode('<doc/>'));
+            parser.finish();
+            nested.finish();
+            expect(outer).to.deep.equal([
+                ['startDocument'],
+                ['startElementNs', 'doc', null, null, [], []],
+                ['endElementNs', 'doc', null, null],
+                ['endDocument'],
+            ]);
+            expect(inner).to.deep.equal([
+                ['startDocument'],
+                ['startElementNs', 'nested', null, null, [], []],
+                ['endElementNs', 'nested', null, null],
+                ['endDocument'],
+            ]);
+        });
+
+        it('accepts the parser again once the callback has returned', () => {
+            const names: string[] = [];
+            using parser = XmlSaxParser.create({
+                startElementNs: (localName) => {
+                    names.push(localName);
+                    expect(() => parser.push(encoder.encode('x'))).to.throw(
+                        XmlError,
+                        'The parser cannot be re-entered from a handler callback',
+                    );
+                },
+            });
+            parser.push(encoder.encode('<doc>'));
+            parser.push(encoder.encode('<child/></doc>'));
+            parser.finish();
+            expect(names).to.deep.equal(['doc', 'child']);
+        });
+    });
+
+    describe('garbage collection', () => {
+        it('collects a parser whose handler refers back to it', async () => {
+            // the documented way to call stop() makes the handler reference its
+            // own parser; that must not keep the parser from being collected
+            diag.configure({ enabled: true });
+            try {
+                {
+                    const parser: XmlSaxParser = XmlSaxParser.create({
+                        startElementNs: () => parser.stop(),
+                    });
+                    parser.push(encoder.encode('<doc><child/></doc>'));
+                }
+                expect(diag.report().XmlSaxParser.totalInstances).to.equal(1);
+
+                for (let i = 0; i < 3; i += 1) { // try 3 times
+                    (global as any).gc();
+                    // allow the finalizer to run
+                    // eslint-disable-next-line no-await-in-loop
+                    await new Promise((resolve) => {
+                        setTimeout(resolve, 0);
+                    });
+                }
+
+                expect(diag.report().XmlSaxParser.garbageCollected).to.equal(1);
+            } finally {
+                diag.configure({ enabled: false });
+            }
+        });
+    });
+
+    describe('handler exceptions', () => {
+        it('rethrows the exception from push and aborts parsing', () => {
+            const failure = new Error('boom');
+            const names: string[] = [];
+            using parser = XmlSaxParser.create({
+                startElementNs: (localName) => {
+                    names.push(localName);
+                    if (localName === 'b') {
+                        throw failure;
+                    }
+                },
+            });
+            expect(() => parser.push(encoder.encode('<doc><a/><b/><c/></doc>')))
+                .to.throw(failure);
+            expect(names).to.deep.equal(['doc', 'a', 'b']);
+            expect(() => parser.push(encoder.encode('x'))).to.throw(
+                XmlError,
+                'Parsing is already terminated',
+            );
+        });
+
+        it('rethrows the exception from finish', () => {
+            const failure = new Error('boom');
+            using parser = XmlSaxParser.create({
+                endDocument: () => {
+                    throw failure;
+                },
+            });
+            parser.push(encoder.encode('<doc/>'));
+            expect(() => parser.finish()).to.throw(failure);
+        });
+    });
+
+    describe('instance isolation', () => {
+        it('keeps interleaved parsers independent', () => {
+            const first: SaxEvent[] = [];
+            const second: SaxEvent[] = [];
+            using parser1 = XmlSaxParser.create(recordingHandler(first));
+            using parser2 = XmlSaxParser.create(recordingHandler(second));
+            parser1.push(encoder.encode('<one><a>'));
+            parser2.push(encoder.encode('<two>'));
+            parser1.push(encoder.encode('1</a>'));
+            parser2.push(encoder.encode('2</two>'));
+            parser2.finish();
+            parser1.push(encoder.encode('</one>'));
+            parser1.finish();
+            expect(first).to.deep.equal([
+                ['startDocument'],
+                ['startElementNs', 'one', null, null, [], []],
+                ['startElementNs', 'a', null, null, [], []],
+                ['characters', '1'],
+                ['endElementNs', 'a', null, null],
+                ['endElementNs', 'one', null, null],
+                ['endDocument'],
+            ]);
+            expect(second).to.deep.equal([
+                ['startDocument'],
+                ['startElementNs', 'two', null, null, [], []],
+                ['characters', '2'],
+                ['endElementNs', 'two', null, null],
+                ['endDocument'],
+            ]);
+        });
+    });
+
+    describe('disposal', () => {
+        it('is idempotent', () => {
+            const parser = XmlSaxParser.create({});
+            parser.dispose();
+            parser.dispose();
+        });
+
+        it('rejects input after dispose', () => {
+            const parser = XmlSaxParser.create({});
+            parser.dispose();
+            expect(() => parser.push(encoder.encode('<doc/>'))).to.throw(
+                XmlError,
+                'The parser is disposed',
+            );
+            expect(() => parser.finish()).to.throw(XmlError, 'The parser is disposed');
+            // the diagnostics are released with the parser, rather than
+            // silently reported as none
+            expect(() => parser.warnings).to.throw(XmlError, 'The parser is disposed');
+            expect(() => parser.errors).to.throw(XmlError, 'The parser is disposed');
+        });
+
+        it('supports using declarations', () => {
+            let leaked: XmlSaxParser;
+            {
+                using parser = XmlSaxParser.create({});
+                parser.push(encoder.encode('<doc/>'));
+                parser.finish();
+                leaked = parser;
+            }
+            expect(() => leaked.push(encoder.encode('x'))).to.throw(
+                XmlError,
+                'The parser is disposed',
+            );
+        });
+    });
+});

--- a/typedoc.config.mjs
+++ b/typedoc.config.mjs
@@ -38,6 +38,7 @@ export default {
     projectDocuments: [
         'docs/tutorial.md',
         'docs/io.md',
+        'docs/sax.md',
         'docs/manipulate.md',
         'docs/mem.md',
         'docs/performance.md',


### PR DESCRIPTION
## What this adds

A new `XmlSaxParser` for parsing large XML files without loading them entirely into memory. Instead of building a complete document tree like `XmlDocument` does, the parser processes chunks of raw bytes and fires callbacks for each piece it encounters — opening and closing tags, text content, comments, and so on.

This is useful when you're working with very large XML files and either don't need the whole document in memory at once, or only care about specific parts of it.

## How it works

You create a parser with a set of optional callbacks, then feed it byte chunks:

```js
import fs from 'node:fs';
import { XmlSaxParser } from 'libxml2-wasm';

const decoder = new TextDecoder();
let inTitle = false;
let title = '';

using parser = XmlSaxParser.create({
    startElementNs(localName) { inTitle = localName === 'title'; },
    endElementNs() { inTitle = false; },
    characters(data) {
        if (inTitle) title += decoder.decode(data, { stream: true });
    },
});

for await (const chunk of fs.createReadStream('doc.xml')) {
    parser.push(chunk);
}
parser.finish();
```

The parser handles the messy parts for you: chunks might split in the middle of a tag or even a UTF-8 character, but the parser reassembles them transparently. (One text node may still arrive as several `characters` calls, hence the streaming `TextDecoder` in the example.) Encoding is detected from the BOM or XML declaration, and callbacks always receive UTF-8 bytes.

## Why this matters

**Memory efficiency.** A gigabyte XML file doesn't require a gigabyte of memory — the parser only keeps what it's actively working on in the buffer.

**Pay for what you use.** Callbacks are optional. If you don't care about processing instructions, you don't register that callback, and the events are skipped without even crossing the WebAssembly boundary. Large text nodes can be inspected as direct references to the parser's memory — valid only for the duration of the callback — rather than copied into JavaScript strings. And when you've seen the part of the document you care about, `stop()` ends the parse early without an error.

**Clear error handling.** If the XML becomes unparsable, `push` throws immediately. When `finish` returns without throwing, you know the whole document was well-formed — including namespace rules, which plain parseability alone doesn't cover. Non-fatal diagnostics are collected in a `warnings` getter instead of interrupting the parse.

**Safe boundaries.** Exceptions thrown in callbacks abort the parse cleanly rather than corrupting libxml2's internal state. Re-entering the parser from a callback is rejected with an error instead of silently breaking things.

## What changed internally

- Exposed libxml2's push-parser functions to the WASM binding
- Refactored error construction so both SAX and DOM parsing can report problems consistently
- Added comprehensive documentation (docs/sax.md) covering feeding strategies, encoding, entity quirks, and memory management

## Compatibility notes

The parser rejects options that don't work in streaming mode (like DTD validation, which requires a complete tree) rather than silently misbehaving. Most standard parsing options are supported. The API is marked `@alpha` while the interface stabilizes based on feedback.
